### PR TITLE
Fix cache bust timestamp creation for custom panel

### DIFF
--- a/custom_components/pp_reader/__init__.py
+++ b/custom_components/pp_reader/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Callable, Mapping
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Final
 
@@ -114,7 +114,7 @@ async def _register_panel_if_absent(hass: HomeAssistant, entry: ConfigEntry) -> 
         return
 
     try:
-        cache_bust = datetime.now(datetime.UTC).strftime("%Y%m%d%H%M%S")
+        cache_bust = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
         await panel_custom_async_register_panel(
             hass,
             frontend_url_path="ppreader",


### PR DESCRIPTION
## Summary
- use `timezone.utc` when generating the custom panel cache bust parameter so the integration works on Python builds without `datetime.UTC`

## Testing
- ./scripts/lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a0b8fb908330ab11f88f9b7088fd