### PR TITLE
Address Ruff TRY300 in pp_reader sensor setup

### DIFF
--- a/custom_components/pp_reader/sensor.py
+++ b/custom_components/pp_reader/sensor.py
@@ -24,8 +24,6 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> bool:
     """Initialisiere alle Sensoren für pp_reader."""
-    # Zugriff auf den Coordinator aus hass.data
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
     try:
         # Zugriff auf den Coordinator aus hass.data
         coordinator: PPReaderCoordinator = hass.data[DOMAIN][config_entry.entry_id][
@@ -69,8 +67,8 @@ async def async_setup_entry(
         # 🔥 Sensoren an HA übergeben
         async_add_entities(sensors)
 
-        return True  # noqa: TRY300
-
     except Exception:
         _LOGGER.exception("Fehler beim Setup der Sensoren")
         return False
+
+    return True


### PR DESCRIPTION
## Summary
- remove the redundant coordinator fetch in the sensor setup
- move the success return outside of the try block so Ruff passes without a noqa while keeping behaviour the same

## Testing
- ./scripts/lint *(fails: existing lint violations in other modules such as custom_components/pp_reader/logic/securities.py and validators.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a992af148330a5c770e400085b94