### PR TITLE
fix: use absolute import in reader

### DIFF
--- a/custom_components/pp_reader/data/reader.py
+++ b/custom_components/pp_reader/data/reader.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import google.protobuf.message
 
-from ..name.abuchen.portfolio import client_pb2
+from custom_components.pp_reader.name.abuchen.portfolio import client_pb2
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.debug(dir(client_pb2))


### PR DESCRIPTION
## Summary
- replace the relative client protobuf import in the portfolio reader with an absolute import to satisfy Ruff TID252

## Testing
- ./scripts/lint *(fails: existing lint violations in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bc5a59fc83309728cf181b70d936