### PR TITLE
Fix Ruff violation in provider base docstring

### DIFF
--- a/custom_components/pp_reader/prices/provider_base.py
+++ b/custom_components/pp_reader/prices/provider_base.py
@@ -38,7 +38,8 @@ class Quote:
 
     Attribute:
         symbol: Ursprüngliches Symbol aus Autodiscovery (keine Normalisierung).
-        price: Letzter Preis (float, ungefiltert; Provider garantiert >0 bei gültigen Quotes).
+        price: Letzter Preis (float, ungefiltert).
+            Provider garantiert > 0 bei gültigen Quotes.
         previous_close: Vorheriger Schlusskurs.
         currency: Währungscode der Quote (für Drift-Prüfung, wird nicht persistiert).
         volume: Handelsvolumen (optional).


### PR DESCRIPTION
## Summary
- wrap the `Quote.price` docstring entry in `provider_base` so Ruff no longer reports a line-length violation while preserving the original guidance for callers

## Testing
- ./scripts/lint *(fails: existing Ruff issues outside the touched module, e.g. unused imports and long docstring lines in `custom_components/pp_reader/logic/securities.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c818ecc083309c55b908fe743b8a