### PR TITLE
Fix Ruff warnings in symbols loader

### DIFF
--- a/custom_components/pp_reader/prices/symbols.py
+++ b/custom_components/pp_reader/prices/symbols.py
@@ -24,7 +24,10 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 __all__ = ["load_active_security_symbols"]
@@ -61,10 +64,11 @@ def load_active_security_symbols(db_path: Path) -> list[tuple[str, str]]:
             """
         )
         rows = [(r[0], r[1]) for r in cur.fetchall()]
-        _LOGGER.debug("Symbol-Autoload: %d aktive Symbole geladen", len(rows))
-        return rows
     except sqlite3.Error:
         _LOGGER.exception("Symbol-Autoload: Fehler beim Ausführen der Symbol-Query")
         return []
+    else:
+        _LOGGER.debug("Symbol-Autoload: %d aktive Symbole geladen", len(rows))
+        return rows
     finally:
         conn.close()


### PR DESCRIPTION
## Summary
- move the pathlib Path import behind a TYPE_CHECKING guard to satisfy Ruff TC003 while keeping runtime behavior unchanged
- restructure the database query try/except flow to return from an else block, preserving logging and behavior while resolving Ruff TRY300

## Testing
- ./scripts/lint *(fails: existing Ruff findings in other modules such as custom_components/pp_reader/__init__.py and logic/securities.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c83c440c8330bc1d491bb6f63807