### PR TITLE
Refactor securities logic to satisfy Ruff

### DIFF
--- a/custom_components/pp_reader/logic/securities.py
+++ b/custom_components/pp_reader/logic/securities.py
@@ -11,47 +11,109 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
-# Removed deprecated typing.List
-from ..currencies.fx import (
+from custom_components.pp_reader.currencies.fx import (
     ensure_exchange_rates_for_dates_sync,
     load_latest_rates_sync,
 )
-from ..data.db_access import Transaction
-from ..logic.portfolio import normalize_price, normalize_shares
+from custom_components.pp_reader.data.db_access import Transaction
+from custom_components.pp_reader.logic.portfolio import (
+    normalize_price,
+    normalize_shares,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+PURCHASE_TYPES = {0, 2}
+SALE_TYPES = {1, 3}
+
+
+def _is_relevant_transaction(transaction: Transaction) -> bool:
+    """Return ``True`` when a transaction has both a security and portfolio."""
+    return bool(transaction.security and transaction.portfolio)
+
+
+def _collect_fx_requirements(
+    transactions: list[Transaction],
+) -> tuple[set[datetime], set[str]]:
+    """Collect all non-EUR currencies and their relevant dates."""
+    fx_dates: set[datetime] = set()
+    fx_currencies: set[str] = set()
+
+    for tx in transactions:
+        if _is_relevant_transaction(tx) and tx.currency_code != "EUR":
+            fx_currencies.add(tx.currency_code)
+            fx_dates.add(datetime.fromisoformat(tx.date))
+
+    return fx_dates, fx_currencies
+
+
+def _determine_exchange_rate(
+    transaction: Transaction, tx_date: datetime, db_path: Path
+) -> float | None:
+    """Load the exchange rate for a transaction."""
+    fx_rates = load_latest_rates_sync(tx_date, db_path)
+
+    if transaction.currency_code == "EUR":
+        return 1.0
+
+    rate = fx_rates.get(transaction.currency_code)
+    if not rate:
+        _LOGGER.warning(
+            "⚠️ Kein Wechselkurs gefunden: Datum=%s, Währung=%s",
+            tx_date.strftime("%Y-%m-%d"),
+            transaction.currency_code,
+        )
+
+    return rate
+
+
+def _apply_sale_fifo(
+    existing_holdings: list[tuple[float, float, datetime]],
+    shares_to_sell: float,
+) -> list[tuple[float, float, datetime]]:
+    """Reduce holdings using FIFO when selling shares."""
+    remaining_to_sell = shares_to_sell
+    updated_positions: list[tuple[float, float, datetime]] = []
+
+    for qty, price, date in existing_holdings:
+        if remaining_to_sell <= 0:
+            updated_positions.append((qty, price, date))
+            continue
+
+        if qty > remaining_to_sell:
+            updated_positions.append((qty - remaining_to_sell, price, date))
+            remaining_to_sell = 0
+        else:
+            remaining_to_sell -= qty
+
+    return updated_positions
 
 
 def db_calculate_current_holdings(
     transactions: list[Transaction],
 ) -> dict[tuple[str, str], float]:
     """
-    Berechnet die aktuell im Bestand befindliche Anzahl pro Wertpapier (security) und Depot (portfolio).
+    Berechne die aktuell gehaltene Anzahl pro Wertpapier und Depot.
 
     Args:
-        transactions (List[Transaction]): Liste aller Transaktionen aus der Datenbank.
+        transactions (list[Transaction]): Liste aller Transaktionen aus der Datenbank.
 
     Returns:
-        Dict[Tuple[str, str], float]: Ein Dictionary, das die Kombination aus Depot-UUID (`portfolio_uuid`)
-                                      und Wertpapier-UUID (`security_uuid`) den aktuellen Beständen (`current_holdings`) zuordnet.
+        Dict[Tuple[str, str], float]: Ein Dictionary mit Depot-UUID
+            (`portfolio_uuid`) und Wertpapier-UUID (`security_uuid`), das den
+            aktuellen Beständen (`current_holdings`) zugeordnet ist.
 
     """
     portfolio_securities_holdings: dict[tuple[str, str], float] = {}
 
     for tx in transactions:
         if not tx.security or not tx.portfolio:
-            continue  # Überspringe Transaktionen ohne zugeordnetes Wertpapier oder Depot
+            continue  # Überspringe Transaktionen ohne Wertpapier oder Depot
 
         key = (tx.portfolio, tx.security)
         shares = (
             normalize_shares(tx.shares) if tx.shares else 0
         )  # Wende normalize_shares an
-
-        # _LOGGER.debug(
-        #     "Berechne current_holdings: portfolio_uuid=%s,",  # noqa: ERA001
-        #     security_uuid=%s, shares=%f tx.portfolio,
-        #     tx.security, shares
-        # )  # noqa: ERA001, RUF100
 
         # Transaktionstypen auswerten
         if tx.type in (0, 2):  # PURCHASE, INBOUND_DELIVERY
@@ -70,103 +132,37 @@ def db_calculate_current_holdings(
 def db_calculate_sec_purchase_value(
     transactions: list[Transaction], db_path: Path
 ) -> dict[tuple[str, str], float]:
-    """
-    Berechnet den gesamten Kaufpreis des aktuellen Bestands pro Wertpapier (FIFO) und Depot.
-
-    Args:
-        transactions (List[Transaction]): Liste aller Transaktionen aus der Datenbank.
-        db_path (Path): Pfad zur SQLite-Datenbank.
-
-    Returns:
-        Dict[Tuple[str, str], float]: Ein Dictionary, das die Kombination aus Depot-UUID (`portfolio_uuid`)
-                                      und Wertpapier-UUID (`security_uuid`) den gesamten Kaufpreisen (`purchase_value`) zuordnet.
-
-    """
+    """Berechne den gesamten Kaufpreis des aktuellen Bestands (FIFO)."""
     portfolio_securities_purchase_values: dict[tuple[str, str], float] = {}
-    holdings: dict[
-        tuple[str, str], list[tuple[float, float, datetime]]
-    ] = {}  # FIFO-Liste pro Depot und Wertpapier
+    holdings: dict[tuple[str, str], list[tuple[float, float, datetime]]] = {}
 
-    # Vor der Transaktionsverarbeitung: Alle benötigten Währungen und Daten sammeln
-    fx_dates = set()
-    fx_currencies = set()
-
-    for tx in transactions:
-        if not tx.security or not tx.portfolio:
-            continue
-        if tx.currency_code != "EUR":
-            fx_currencies.add(tx.currency_code)
-            fx_dates.add(datetime.fromisoformat(tx.date))
-
-    # Wechselkurse vorab laden
+    fx_dates, fx_currencies = _collect_fx_requirements(transactions)
     if fx_currencies:
         ensure_exchange_rates_for_dates_sync(list(fx_dates), fx_currencies, db_path)
 
     for tx in transactions:
-        if not tx.security or not tx.portfolio:
+        if not _is_relevant_transaction(tx):
             continue
 
         key = (tx.portfolio, tx.security)
-        shares = (
-            normalize_shares(tx.shares) if tx.shares else 0
-        )  # Wende normalize_shares an
+        shares = normalize_shares(tx.shares) if tx.shares else 0
         amount = tx.amount / 100  # Cent -> EUR
         tx_date = datetime.fromisoformat(tx.date)
-
-        # Wechselkurs laden (synchron)
-        fx_rates = load_latest_rates_sync(tx_date, db_path)
-        rate = fx_rates.get(tx.currency_code) if tx.currency_code != "EUR" else 1.0
-
-        if tx.currency_code != "EUR":
-            if not rate:
-                _LOGGER.warning(
-                    "⚠️ Kein Wechselkurs gefunden: Datum=%s, Währung=%s",
-                    tx_date.strftime("%Y-%m-%d"),
-                    tx.currency_code,
-                )
-            # else:
-            #     _LOGGER.debug(
-            #         "Wechselkurs gefunden: Datum=%s, Währung=%s, Kurs=%f",
-            #         tx_date.strftime("%Y-%m-%d"), tx.currency_code, rate
-            #     )
+        rate = _determine_exchange_rate(tx, tx_date, db_path)
 
         if not rate:
-            continue  # Überspringe Transaktionen ohne gültigen Wechselkurs
+            continue
 
-        if tx.type in (0, 2):  # PURCHASE, INBOUND_DELIVERY
+        if tx.type in PURCHASE_TYPES:
             price_per_share = amount / shares if shares != 0 else 0
             price_per_share_eur = price_per_share / rate
             holdings.setdefault(key, []).append((shares, price_per_share_eur, tx_date))
+        elif tx.type in SALE_TYPES:
+            holdings[key] = _apply_sale_fifo(holdings.get(key, []), shares)
 
-        elif tx.type in (1, 3):  # SALE, OUTBOUND_DELIVERY
-            remaining_to_sell = shares
-            existing = holdings.get(key, [])
-            updated = []
-
-            for qty, price, date in existing:
-                if remaining_to_sell <= 0:
-                    updated.append((qty, price, date))
-                    continue
-                if qty > remaining_to_sell:
-                    updated.append((qty - remaining_to_sell, price, date))
-                    remaining_to_sell = 0
-                else:
-                    remaining_to_sell -= qty
-
-            holdings[key] = updated
-
-    # Summe der verbleibenden Positionen berechnen
     for key, positions in holdings.items():
-        total_purchase = 0.0
-        for qty, price, _ in positions:
-            if qty > 0:
-                total_purchase += qty * price
+        total_purchase = sum(qty * price for qty, price, _ in positions if qty > 0)
         portfolio_securities_purchase_values[key] = round(total_purchase, 2)
-
-        # _LOGGER.debug(
-        #     "Berechne purchase_value: portfolio_uuid=%s, security_uuid=%s, total_purchase=%f",
-        #     key[0], key[1], total_purchase
-        # )
 
     return portfolio_securities_purchase_values
 
@@ -176,25 +172,12 @@ def db_calculate_holdings_value(
     conn: sqlite3.Connection,
     current_hold_pur: dict[tuple[str, str], dict[str, float]],
 ) -> dict[tuple[str, str], dict[str, float]]:
-    """
-    Berechnet den aktuellen Wert (current_value) für jede Position in current_holdings.
-
-    Args:
-        db_path (Path): Pfad zur SQLite-Datenbank.
-        conn (sqlite3.Connection): Bestehende Verbindung zur SQLite-Datenbank.
-        current_holdings (Dict[Tuple[str, str], Dict[str, float]]): Dictionary mit Beständen und Kaufwerten.
-
-    Returns:
-        Dict[Tuple[str, str], Dict[str, float]]: Das ursprüngliche Dictionary, ergänzt um den aktuellen Wert (current_value).
-
-    """
-    # _LOGGER.debug("db_calculate_holdings_value: Berechnung des aktuellen Werts gestartet.")
-
+    """Berechne den aktuellen Wert (``current_value``) für alle Positionen."""
     # Sammle alle benötigten Währungen
     needed_currencies = set()
     cur = conn.cursor()
 
-    for (portfolio_uuid, security_uuid), data in current_hold_pur.items():
+    for _portfolio_uuid, security_uuid in current_hold_pur:
         cur.execute(
             """
             SELECT currency_code FROM securities WHERE uuid = ?
@@ -236,7 +219,6 @@ def db_calculate_holdings_value(
             rate = fx_rates.get(currency_code)
             if rate:
                 latest_price /= rate  # Wende den Wechselkurs an
-                # _LOGGER.debug("Angewendeter Wechselkurs für %s: %f", currency_code, rate)
             else:
                 _LOGGER.warning(
                     "⚠️ Kein Wechselkurs für %s gefunden. Überspringe Berechnung.",
@@ -251,10 +233,5 @@ def db_calculate_holdings_value(
         current_hold_pur[(portfolio_uuid, security_uuid)]["current_value"] = round(
             current_value, 2
         )
-
-        # _LOGGER.debug(
-        #     "Berechneter Wert: portfolio_uuid=%s, security_uuid=%s, current_value=%f",
-        #     portfolio_uuid, security_uuid, current_value
-        # )
 
     return current_hold_pur


### PR DESCRIPTION
## Summary
- switch securities logic imports to package-absolute paths required by Ruff's tidy plugin
- refactor purchase value calculation into helper utilities to reduce branching while preserving FIFO behavior
- clean up docstrings and remove unused debug comments to meet Ruff's formatting rules

## Testing
- `./scripts/lint` *(fails: existing lint violations elsewhere in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c7d65f808330b3b1a0f76175620f