### PR TITLE
Refine gain sensors to satisfy Ruff

### DIFF
--- a/custom_components/pp_reader/sensors/gain_sensors.py
+++ b/custom_components/pp_reader/sensors/gain_sensors.py
@@ -1,5 +1,11 @@
+"""Sensor entities exposing unrealized gains for portfolios."""
+
+from __future__ import annotations
+
 import logging
-import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -10,22 +16,59 @@ from custom_components.pp_reader.logic.portfolio import (
     calculate_unrealized_gain_pct,
 )
 
+if TYPE_CHECKING:
+    from custom_components.pp_reader.sensors.depot_sensors import (
+        PortfolioDepotSensor,
+    )
+    from custom_components.pp_reader.sensors.purchase_sensors import (
+        PortfolioPurchaseSensor,
+    )
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_portfolio_name(depot_sensor: PortfolioDepotSensor) -> str:
+    """Return the portfolio name associated with the provided depot sensor."""
+    attributes = depot_sensor.extra_state_attributes or {}
+    portfolio_uuid = attributes.get("portfolio_uuid")
+
+    if portfolio_uuid:
+        portfolios = depot_sensor.coordinator.data.get("portfolios")
+        if isinstance(portfolios, Mapping):
+            portfolio_data = portfolios.get(portfolio_uuid)
+            if isinstance(portfolio_data, Mapping):
+                name = portfolio_data.get("name")
+                if isinstance(name, str) and name:
+                    return name
+
+    entity_name = depot_sensor.name or ""
+    if entity_name.startswith("Depotwert "):
+        return entity_name.removeprefix("Depotwert ")
+    return entity_name or "Unbekannt"
 
 
 class PortfolioGainAbsSensor(CoordinatorEntity, SensorEntity):
     """Sensor für den Kursgewinn (absolut) eines Depots."""
 
-    def __init__(self, depot_sensor, purchase_sensor):
+    def __init__(
+        self,
+        depot_sensor: PortfolioDepotSensor,
+        purchase_sensor: PortfolioPurchaseSensor,
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(depot_sensor.coordinator)
         self._depot_sensor = depot_sensor
         self._purchase_sensor = purchase_sensor
 
         # db_path direkt vom Coordinator abrufen
-        base = os.path.basename(depot_sensor.coordinator.db_path)
-        self._attr_name = f"Kursgewinn absolut {depot_sensor._portfolio_name}"
-        self._attr_unique_id = f"{slugify(base)}_kursgewinn_absolut_{slugify(depot_sensor._portfolio_name)}"
+        base = Path(depot_sensor.coordinator.db_path).name
+        self._portfolio_name = _resolve_portfolio_name(depot_sensor)
+        slugified_base = slugify(base)
+        slugified_portfolio = slugify(self._portfolio_name)
+        self._attr_name = f"Kursgewinn absolut {self._portfolio_name}"
+        self._attr_unique_id = (
+            f"{slugified_base}_kursgewinn_absolut_{slugified_portfolio}"
+        )
         self._attr_native_unit_of_measurement = "€"
         self._attr_icon = "mdi:chart-line-variant"
         self._attr_should_poll = True
@@ -33,34 +76,46 @@ class PortfolioGainAbsSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = "measurement"  # Zustandsklasse hinzufügen
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         """Wert des Sensors."""
+        current_value = self._depot_sensor.native_value
+        purchase_value = self._purchase_sensor.native_value
         try:
             gain = calculate_unrealized_gain(
-                self._depot_sensor.native_value, self._purchase_sensor.native_value
+                float(current_value),
+                float(purchase_value),
             )
             return round(gain, 2)
-        except Exception as e:
-            _LOGGER.error(
-                "❌ Fehler beim Berechnen des Kursgewinns für %s: %s",
-                self._depot_sensor._portfolio_name,
-                str(e),
+        except (TypeError, ValueError) as err:
+            message = (
+                "❌ Fehler beim Berechnen des Kursgewinns für "
+                f"{self._portfolio_name}: {err}"
             )
+            _LOGGER.exception(message)
             return None
 
 
 class PortfolioGainPctSensor(CoordinatorEntity, SensorEntity):
     """Sensor für den Kursgewinn (prozentual) eines Depots."""
 
-    def __init__(self, depot_sensor, purchase_sensor):
+    def __init__(
+        self,
+        depot_sensor: PortfolioDepotSensor,
+        purchase_sensor: PortfolioPurchaseSensor,
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(depot_sensor.coordinator)
         self._depot_sensor = depot_sensor
         self._purchase_sensor = purchase_sensor
 
-        base = os.path.basename(depot_sensor.coordinator.db_path)
-        self._attr_name = f"Kursgewinn % {depot_sensor._portfolio_name}"
-        self._attr_unique_id = f"{slugify(base)}_kursgewinn_prozent_{slugify(depot_sensor._portfolio_name)}"
+        base = Path(depot_sensor.coordinator.db_path).name
+        self._portfolio_name = _resolve_portfolio_name(depot_sensor)
+        slugified_base = slugify(base)
+        slugified_portfolio = slugify(self._portfolio_name)
+        self._attr_name = f"Kursgewinn % {self._portfolio_name}"
+        self._attr_unique_id = (
+            f"{slugified_base}_kursgewinn_prozent_{slugified_portfolio}"
+        )
         self._attr_native_unit_of_measurement = "%"
         self._attr_icon = "mdi:percent"
         self._attr_should_poll = True
@@ -68,17 +123,20 @@ class PortfolioGainPctSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = "measurement"  # Zustandsklasse hinzufügen
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         """Wert des Sensors."""
+        current_value = self._depot_sensor.native_value
+        purchase_value = self._purchase_sensor.native_value
         try:
             gain = calculate_unrealized_gain_pct(
-                self._depot_sensor.native_value, self._purchase_sensor.native_value
+                float(current_value),
+                float(purchase_value),
             )
             return round(gain, 2)
-        except Exception as e:
-            _LOGGER.error(
-                "❌ Fehler beim Berechnen des Kursgewinns (%) für %s: %s",
-                self._depot_sensor._portfolio_name,
-                str(e),
+        except (TypeError, ValueError) as err:
+            message = (
+                "❌ Fehler beim Berechnen des Kursgewinns (%) für "
+                f"{self._portfolio_name}: {err}"
             )
+            _LOGGER.exception(message)
             return None


### PR DESCRIPTION
## Summary
- add module documentation, type hints, and pathlib usage to the gain sensors module
- resolve private-attribute access by deriving portfolio names from coordinator data
- tighten error handling and logging so Ruff checks pass without altering Home Assistant behavior

## Testing
- ./scripts/lint *(fails: existing lint violations throughout the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c88852c88330b0881a47b1f61821