### PR TITLE
Handle missing protobuf dependencies lazily

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,2 @@
+"""Namespace package for Home Assistant custom components used in tests."""
+

--- a/pp_reader/__init__.py
+++ b/pp_reader/__init__.py
@@ -1,0 +1,2 @@
+"""Compatibility package exposing pp_reader helpers for unit tests."""
+

--- a/pp_reader/currencies/__init__.py
+++ b/pp_reader/currencies/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility layer exposing currency helpers for legacy imports."""
+
+from custom_components.pp_reader.currencies.fx import (
+    ensure_exchange_rates_for_dates,
+    ensure_exchange_rates_for_dates_sync,
+    load_latest_rates,
+    load_latest_rates_sync,
+)
+
+__all__ = [
+    "ensure_exchange_rates_for_dates",
+    "ensure_exchange_rates_for_dates_sync",
+    "load_latest_rates",
+    "load_latest_rates_sync",
+]
+

--- a/pp_reader/currencies/fx.py
+++ b/pp_reader/currencies/fx.py
@@ -1,0 +1,20 @@
+"""Proxy module exposing currency helpers under the `pp_reader` namespace."""
+
+from custom_components.pp_reader.currencies.fx import (
+    ensure_exchange_rates_for_dates,
+    ensure_exchange_rates_for_dates_sync,
+    get_exchange_rates,
+    get_required_currencies,
+    load_latest_rates,
+    load_latest_rates_sync,
+)
+
+__all__ = [
+    "ensure_exchange_rates_for_dates",
+    "ensure_exchange_rates_for_dates_sync",
+    "get_exchange_rates",
+    "get_required_currencies",
+    "load_latest_rates",
+    "load_latest_rates_sync",
+]
+


### PR DESCRIPTION
## Summary
- add namespace packages so tests can import custom_components and pp_reader helpers directly
- defer heavy integration imports until runtime in the main entrypoint and coordinator to avoid requiring protobuf during import
- guard protobuf usage and provide compatibility shims for currency helpers so optional dependencies raise clear errors only when needed

## Testing
- python -m pytest tests/prices/test_migration.py -vv

------
https://chatgpt.com/codex/tasks/task_e_68d7d921182083309b5201df0aed3bdc