### PR TITLE
Fix timezone handling for FX data

### DIFF
--- a/custom_components/pp_reader/data/websocket.py
+++ b/custom_components/pp_reader/data/websocket.py
@@ -222,7 +222,7 @@ async def ws_get_accounts(
                     )
                     _LOGGER.warning(message)
                 else:
-                    today = datetime.now(datetime.UTC)
+                    today = datetime.now(timezone.utc)  # noqa: UP017
                     await ensure_rates([today], active_fx_currencies, db_path)
                     fx_rates = await load_rates(today, db_path)
         except Exception:  # noqa: BLE001
@@ -325,7 +325,7 @@ async def ws_get_last_file_update(
             try:
                 parsed_update = datetime.strptime(
                     last_file_update_raw, "%Y-%m-%dT%H:%M:%S"
-                ).replace(tzinfo=timezone.utc)
+                ).replace(tzinfo=timezone.utc)  # noqa: UP017
                 last_file_update = parsed_update.strftime("%d.%m.%Y, %H:%M")
             except ValueError:
                 _LOGGER.exception("Fehler beim Parsen des Zeitstempels")

--- a/custom_components/pp_reader/logic/validators.py
+++ b/custom_components/pp_reader/logic/validators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, ClassVar
 
 try:  # pragma: no cover - dependency optional for unit tests
@@ -124,8 +124,11 @@ class PPDataValidator:
             )
 
         try:
-            tx_date = datetime.fromtimestamp(tx.date.seconds, tz=datetime.UTC)
-            now_utc = datetime.now(tz=datetime.UTC)
+            tx_date = datetime.fromtimestamp(
+                tx.date.seconds,
+                tz=timezone.utc,  # noqa: UP017
+            )
+            now_utc = datetime.now(tz=timezone.utc)  # noqa: UP017
             if tx_date > now_utc:
                 return ValidationResult(
                     is_valid=False,

--- a/tests/test_validators_timezone.py
+++ b/tests/test_validators_timezone.py
@@ -1,0 +1,50 @@
+"""Regression tests for timezone handling in validators."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+from custom_components.pp_reader.logic import validators
+
+
+class DummyProtoDate:
+    """Minimal protobuf-like date wrapper exposing seconds."""
+
+    def __init__(self, seconds: int) -> None:
+        """Store the provided timestamp."""
+        self.seconds = seconds
+
+
+class DummyProtoTransaction:
+    """Mimic the interface used by PPDataValidator."""
+
+    def __init__(self, *, seconds: int) -> None:
+        """Initialise transaction metadata for validation."""
+        self.type = 0
+        self.uuid = "uuid-1"
+        self.date = DummyProtoDate(seconds)
+
+    def HasField(self, name: str) -> bool:  # noqa: N802 - protobuf API compatibility
+        """Replicate protobuf HasField behaviour for specific fields."""
+        return name in {"uuid", "date"}
+
+
+def test_validate_proto_transaction_accepts_current_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transactions with current timestamps validate without timezone errors."""
+    monkeypatch.setattr(validators, "client_pb2", object())
+
+    validator = validators.PPDataValidator()
+
+    now_seconds = int(datetime.now(tz=timezone.utc).timestamp())  # noqa: UP017
+    tx = DummyProtoTransaction(seconds=now_seconds)
+
+    result = validator._validate_proto_transaction(tx)  # noqa: SLF001
+
+    assert result.is_valid  # noqa: S101
+    assert result.message == "PTransaction valid"  # noqa: S101

--- a/tests/test_ws_accounts_fx.py
+++ b/tests/test_ws_accounts_fx.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import sys
 import types
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -34,6 +40,8 @@ _websocket_module = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(_websocket_module)
 
 _collect_active_fx_currencies = _websocket_module._collect_active_fx_currencies  # noqa: SLF001
+WS_GET_ACCOUNTS = _websocket_module.ws_get_accounts.__wrapped__
+DOMAIN = _websocket_module.DOMAIN
 
 
 class DummyAccount:
@@ -59,3 +67,125 @@ def test_collect_active_fx_currencies_filters_invalid_entries() -> None:
     ]
 
     assert _collect_active_fx_currencies(accounts) == {"USD", "CHF"}  # noqa: S101
+
+
+class StubConnection:
+    """Capture websocket responses for inspection."""
+
+    def __init__(self) -> None:
+        """Initialise in-memory buffers for websocket traffic."""
+        self.sent: list[tuple[int | None, dict[str, object]]] = []
+        self.errors: list[tuple[int | None, str, str]] = []
+
+    def send_result(self, msg_id: int | None, payload: dict[str, object]) -> None:
+        """Record a websocket result payload."""
+        self.sent.append((msg_id, payload))
+
+    def send_error(self, msg_id: int | None, code: str, message: str) -> None:
+        """Record a websocket error response."""
+        self.errors.append((msg_id, code, message))
+
+
+class StubHass:
+    """Minimal Home Assistant stub providing executor shim."""
+
+    def __init__(self, entry_id: str, db_path: Path) -> None:
+        """Store minimal registry data for the target entry."""
+        self.data = {DOMAIN: {entry_id: {"db_path": db_path}}}
+
+    async def async_add_executor_job(
+        self, func: Any, *args: Any
+    ) -> Any:
+        """Execute blocking helpers synchronously for tests."""
+        return func(*args)
+
+
+def _make_account(currency: str, balance: int = 10000) -> object:
+    class Account:
+        def __init__(self) -> None:
+            self.currency_code = currency
+            self.is_retired = False
+            self.balance = balance
+            self.name = "Test Account"
+
+    return Account()
+
+
+def _stub_db_path(tmp_path: Path) -> Path:
+    db_path = tmp_path / "portfolio.db"
+    db_path.write_text("stub", encoding="utf-8")
+    return db_path
+
+
+def _run_ws_get_accounts(*args: Any, **kwargs: Any) -> None:
+    """Execute websocket handler synchronously for tests."""
+    asyncio.run(WS_GET_ACCOUNTS(*args, **kwargs))
+
+
+def test_ws_get_accounts_requests_fx_with_utc_timezone(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """FX helper receives timezone aware dates to avoid datetime.UTC dependency."""
+    entry_id = "entry-1"
+    db_path = _stub_db_path(tmp_path)
+    hass = StubHass(entry_id, db_path)
+    connection = StubConnection()
+
+    captured: dict[str, object] = {}
+
+    async def fake_ensure(
+        dates: list[datetime], currencies: set[str], path: Path
+    ) -> None:
+        captured["dates"] = dates
+        captured["currencies"] = currencies
+        captured["ensure_path"] = path
+
+    async def fake_load(date: datetime, path: Path) -> dict[str, float]:
+        captured["load_args"] = (date, path)
+        return {"USD": 1.25}
+
+    def fake_get_accounts(path: Path) -> list[object]:
+        assert path == db_path  # noqa: S101 - ensure handler forwards db_path
+        return [_make_account("USD", balance=12_500)]
+
+    monkeypatch.setattr(
+        _websocket_module,
+        "ensure_exchange_rates_for_dates",
+        fake_ensure,
+    )
+    monkeypatch.setattr(_websocket_module, "load_latest_rates", fake_load)
+    monkeypatch.setattr(_websocket_module, "get_accounts", fake_get_accounts)
+
+    _run_ws_get_accounts(
+        hass,
+        connection,
+        {"id": 7, "type": "pp_reader/get_accounts", "entry_id": entry_id},
+    )
+
+    assert connection.errors == []  # noqa: S101
+    assert connection.sent == [  # noqa: S101
+        (
+            7,
+            {
+                "accounts": [
+                    {
+                        "name": "Test Account",
+                        "currency_code": "USD",
+                        "orig_balance": 125.0,
+                        "balance": 100.0,
+                    }
+                ]
+            },
+        )
+    ]
+
+    dates = captured.get("dates")
+    assert dates is not None  # noqa: S101
+    assert isinstance(dates, list)  # noqa: S101
+    assert dates  # noqa: S101
+    assert dates[0].tzinfo is timezone.utc  # noqa: UP017,S101
+    assert captured.get("currencies") == {"USD"}  # noqa: S101
+    assert captured.get("ensure_path") == db_path  # noqa: S101
+    load_args = captured.get("load_args")
+    assert load_args is not None  # noqa: S101
+    assert load_args[0].tzinfo is timezone.utc  # noqa: UP017,S101


### PR DESCRIPTION
## Summary
- avoid `datetime.UTC` so FX rate loading works on Python builds missing the alias
- update the protobuf validator to use `timezone.utc` and exercise it with a regression test
- extend websocket FX tests to cover timezone-aware rate requests

## Testing
- pytest tests/test_ws_accounts_fx.py tests/test_validators_timezone.py
- ruff check custom_components/pp_reader/data/websocket.py custom_components/pp_reader/logic/validators.py tests/test_ws_accounts_fx.py tests/test_validators_timezone.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e4c7740c833083384a3e6c289feb