### PR TITLE
Fix FX rate persistence locking and portfolio event aggregation

### DIFF
--- a/custom_components/pp_reader/currencies/fx.py
+++ b/custom_components/pp_reader/currencies/fx.py
@@ -23,6 +23,7 @@ import aiohttp
 _LOGGER = logging.getLogger(__name__)
 
 API_URL = "https://api.frankfurter.app"
+SQLITE_TIMEOUT = 30.0
 
 # --- Hilfsfunktionen ---
 
@@ -33,24 +34,31 @@ async def _execute_db(fn: Callable, *args: Any, **kwargs: Any) -> Any:
 
 
 def _load_rates_for_date_sync(db_path: Path, date: str) -> dict[str, float]:
-    conn = sqlite3.connect(str(db_path))
-    cursor = conn.execute("SELECT currency, rate FROM fx_rates WHERE date = ?", (date,))
-    result = {row[0]: row[1] for row in cursor.fetchall()}
-    conn.close()
+    conn = sqlite3.connect(str(db_path), timeout=SQLITE_TIMEOUT)
+    try:
+        cursor = conn.execute(
+            "SELECT currency, rate FROM fx_rates WHERE date = ?",
+            (date,),
+        )
+        result = {row[0]: row[1] for row in cursor.fetchall()}
+    finally:
+        conn.close()
     return result
 
 
 def _save_rates_sync(db_path: Path, date: str, rates: dict[str, float]) -> None:
     if not rates:
         return
-    conn = sqlite3.connect(str(db_path))
-    inserts = [(date, currency, rate) for currency, rate in rates.items()]
-    conn.executemany(
-        "INSERT OR REPLACE INTO fx_rates (date, currency, rate) VALUES (?, ?, ?)",
-        inserts,
-    )
-    conn.commit()
-    conn.close()
+    conn = sqlite3.connect(str(db_path), timeout=SQLITE_TIMEOUT)
+    try:
+        inserts = [(date, currency, rate) for currency, rate in rates.items()]
+        conn.executemany(
+            "INSERT OR REPLACE INTO fx_rates (date, currency, rate) VALUES (?, ?, ?)",
+            inserts,
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 async def _load_rates_for_date(db_path: Path, date: str) -> dict[str, float]:

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -931,7 +931,7 @@ class _SyncRunner:
             return
         portfolio_values: list[dict[str, Any]] = []
         try:
-            portfolio_values = fetch_live_portfolios(self.conn, self.db_path)
+            portfolio_values = fetch_live_portfolios(self.db_path)
             if not portfolio_values:
                 _LOGGER.debug(
                     "sync_from_pclient: Keine Portfolio-Werte für Event vorhanden "


### PR DESCRIPTION
## Summary
- ensure fetch_live_portfolios is invoked with the current db_path-only signature when emitting portfolio events
- add a busy timeout to temporary SQLite connections in the FX module to reduce database locked errors during writes

## Testing
- pytest tests/test_fetch_live_portfolios.py
- ruff check custom_components/pp_reader/currencies/fx.py custom_components/pp_reader/data/sync_from_pclient.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ec8891388330a9c6007adb4f7b6f