### PR TITLE
Serialize FX rate DB writes to prevent locking

### DIFF
--- a/tests/test_currencies_fx.py
+++ b/tests/test_currencies_fx.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
+import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -78,3 +81,46 @@ async def test_save_rates_raises_after_retry(monkeypatch: pytest.MonkeyPatch) ->
             {"USD": 1.1},
             retries=RETRY_THRESHOLD,
         )
+
+
+async def test_concurrent_writes_are_serialized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure concurrent calls to _save_rates are serialized via a threading lock."""
+    active_calls = 0
+    max_concurrent = 0
+    state_lock = threading.Lock()
+
+    def fake_connect(*_args: Any, **_kwargs: Any) -> Any:
+        class DummyConnection:
+            def executemany(self, *_exec_args: Any, **_exec_kwargs: Any) -> None:
+                nonlocal active_calls, max_concurrent
+                with state_lock:
+                    active_calls += 1
+                    max_concurrent = max(max_concurrent, active_calls)
+                try:
+                    time.sleep(0.05)
+                finally:
+                    with state_lock:
+                        active_calls -= 1
+
+            def commit(self) -> None:
+                """No-op commit stub."""
+
+            def close(self) -> None:
+                """No-op close stub."""
+
+        return DummyConnection()
+
+    monkeypatch.setattr(fx.sqlite3, "connect", fake_connect)
+
+    async def call_save() -> None:
+        await fx._save_rates(  # noqa: SLF001
+            Path("dummy.db"),
+            "2025-01-01",
+            {"USD": 1.1},
+        )
+
+    await asyncio.gather(*(call_save() for _ in range(3)))
+
+    assert max_concurrent == 1  # noqa: S101


### PR DESCRIPTION
## Summary
- serialize SQLite FX rate writes with a threading lock to avoid concurrent write contention
- reuse a shared upsert query constant for inserting rates
- extend the FX tests to cover concurrent save calls using the new lock

## Testing
- pytest tests/test_currencies_fx.py
- ruff check custom_components/pp_reader/currencies/fx.py tests/test_currencies_fx.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f63d41208330aaee5294fa9ccd23