### PR TITLE
Commit portfolio sync before FX fetch

### DIFF
--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -659,6 +659,10 @@ class _SyncRunner:
                     new_portfolio_data,
                 )
 
+        # Changes must be committed before other tasks attempt database writes
+        # (e.g. exchange rate updates during portfolio securities sync).
+        self.conn.commit()
+
     def _sync_portfolio_securities(self) -> None:
         if self.cursor is None:
             return

--- a/tests/test_sync_from_pclient.py
+++ b/tests/test_sync_from_pclient.py
@@ -3,11 +3,15 @@
 # ruff: noqa: S101 - pytest assertions are expected in tests
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-from custom_components.pp_reader.data.sync_from_pclient import maybe_field
+from custom_components.pp_reader.data import db_schema
+from custom_components.pp_reader.data import sync_from_pclient as sync_module
+from custom_components.pp_reader.data.sync_from_pclient import _SyncRunner, maybe_field
 
 
 class _NoPresenceProto:
@@ -50,3 +54,62 @@ def test_maybe_field_handles_presence(
 ) -> None:
     """maybe_field should gracefully handle different presence semantics."""
     assert maybe_field(message, field_name) == expected
+
+
+class _DummyPortfolio:
+    """Minimal portfolio stub exposing attributes accessed by the sync runner."""
+
+    def __init__(self, uuid: str) -> None:
+        self.uuid = uuid
+        self.name = "Test Portfolio"
+        self.note = None
+        self.referenceAccount = None
+        self.isRetired = False
+        self.updatedAt = None
+
+    def HasField(self, name: str) -> bool:  # noqa: N802 - proto compatibility
+        return getattr(self, name, None) is not None
+
+
+class _DummyClient:
+    """Provide the minimal client API consumed by ``_SyncRunner``."""
+
+    def __init__(self, portfolios: list[_DummyPortfolio]) -> None:
+        self.transactions: list[Any] = []
+        self.accounts: list[Any] = []
+        self.securities: list[Any] = []
+        self.portfolios = portfolios
+
+
+def _prepare_portfolio_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    for statement in db_schema.PORTFOLIO_SCHEMA:
+        conn.executescript(statement)
+    conn.commit()
+    return conn
+
+
+def test_sync_portfolios_commits_changes(tmp_path: Path) -> None:
+    """Portfolio synchronisation should leave no open transaction."""
+    db_path = tmp_path / "portfolio.db"
+    conn = _prepare_portfolio_db(db_path)
+    original_error = getattr(sync_module, "_TIMESTAMP_IMPORT_ERROR", None)
+    sync_module._TIMESTAMP_IMPORT_ERROR = None  # Ensure timestamp guard stays inactive
+    runner = _SyncRunner(
+        client=_DummyClient([_DummyPortfolio("portfolio-1")]),
+        conn=conn,
+        hass=None,
+        entry_id=None,
+        last_file_update=None,
+        db_path=db_path,
+    )
+
+    runner.cursor = conn.cursor()
+    try:
+        assert not conn.in_transaction
+        runner._sync_portfolios()
+        assert not conn.in_transaction
+    finally:
+        sync_module._TIMESTAMP_IMPORT_ERROR = original_error
+        runner.cursor.close()
+        conn.close()


### PR DESCRIPTION
## Summary
- commit portfolio metadata updates before triggering FX lookups so the exchange-rate writer no longer hits a locked database
- add a regression test that ensures `_sync_portfolios` leaves the SQLite connection out of a transaction

## Testing
- pytest tests/test_sync_from_pclient.py::test_sync_portfolios_commits_changes
- ./scripts/lint *(fails: repository already contains outstanding lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f89c760c8330b4ef77ab43856a71