### PR TITLE
Reduce panels_updated event payload size

### DIFF
--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -100,6 +102,152 @@ DELETE_TABLE_CONFIG = {
 DOMAIN = "pp_reader"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+EVENT_DATA_MAX_BYTES = 32_768
+_EVENT_SIZE_MARGIN = 512
+
+
+def _is_sequence(value: Any) -> bool:
+    """Return True for non-string sequences."""
+    return isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    )
+
+
+def _estimate_event_size(payload: dict[str, Any]) -> int:
+    """Return the JSON encoded size of an event payload in bytes."""
+    try:
+        encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return 0
+    return len(encoded.encode("utf-8"))
+
+
+def _normalize_portfolio_value_entry(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Compact a raw portfolio aggregation entry for event transport."""
+    uuid = item.get("uuid") or item.get("portfolio_uuid")
+    if not uuid:
+        return None
+
+    def _float(value_key: str, fallback_key: str | None = None) -> float:
+        raw = item.get(value_key)
+        if raw is None and fallback_key is not None:
+            raw = item.get(fallback_key)
+        try:
+            return round(float(raw or 0.0), 2)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _int(value_key: str, fallback_key: str | None = None) -> int:
+        raw = item.get(value_key)
+        if raw is None and fallback_key is not None:
+            raw = item.get(fallback_key)
+        try:
+            return int(raw or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    return {
+        "uuid": str(uuid),
+        "position_count": _int("position_count", "count"),
+        "current_value": _float("current_value", "value"),
+        "purchase_sum": _float("purchase_sum"),
+    }
+
+
+def _compact_portfolio_values_payload(data: Any) -> Any:
+    """Remove unused fields from portfolio value updates to keep payloads small."""
+
+    def _compact_items(items: Sequence[Any]) -> list[dict[str, Any]]:
+        compacted: list[dict[str, Any]] = []
+        for item in items:
+            if isinstance(item, Mapping):
+                normalized = _normalize_portfolio_value_entry(item)
+                if normalized is not None:
+                    compacted.append(normalized)
+        return compacted
+
+    if isinstance(data, Mapping):
+        result: dict[str, Any] = {}
+        portfolios = data.get("portfolios")
+        if _is_sequence(portfolios):
+            result["portfolios"] = _compact_items(portfolios)
+        else:
+            normalized = _normalize_portfolio_value_entry(data)
+            if normalized is not None:
+                result["portfolios"] = [normalized]
+
+        # Optional additional keys (e.g. "error") should be propagated if present
+        for optional_key in ("error",):
+            if optional_key in data:
+                result[optional_key] = data[optional_key]
+        return result
+
+    if _is_sequence(data):
+        return _compact_items(data)
+
+    return data
+
+
+def _normalize_position_entry(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Reduce a raw position entry to the fields required by the dashboard."""
+    security_uuid = item.get("security_uuid")
+    if security_uuid:
+        security_uuid = str(security_uuid)
+
+    def _float(value_key: str) -> float:
+        raw = item.get(value_key)
+        try:
+            return round(float(raw or 0.0), 2)
+        except (TypeError, ValueError):
+            return 0.0
+
+    normalized: dict[str, Any] = {
+        "security_uuid": security_uuid,
+        "name": item.get("name"),
+        "current_holdings": item.get("current_holdings", 0),
+        "purchase_value": _float("purchase_value"),
+        "current_value": _float("current_value"),
+        "gain_abs": _float("gain_abs"),
+        "gain_pct": _float("gain_pct"),
+    }
+
+    return normalized
+
+
+def _compact_portfolio_positions_payload(data: Any) -> Any:
+    """Ensure position updates only transport the necessary keys."""
+    if not isinstance(data, Mapping):
+        return data
+
+    positions = data.get("positions")
+    compacted: list[dict[str, Any]] = []
+    if _is_sequence(positions):
+        for item in positions:
+            if isinstance(item, Mapping):
+                normalized = _normalize_position_entry(item)
+                if normalized is not None:
+                    compacted.append(normalized)
+
+    result: dict[str, Any] = {
+        "portfolio_uuid": data.get("portfolio_uuid"),
+        "positions": compacted,
+    }
+    if "error" in data:
+        result["error"] = data["error"]
+    return result
+
+
+def _compact_event_data(data_type: str, data: Any) -> Any:
+    """Return an event payload with redundant fields stripped out."""
+    if data_type == "portfolio_values":
+        return _compact_portfolio_values_payload(data)
+
+    if data_type == "portfolio_positions":
+        return _compact_portfolio_positions_payload(data)
+
+    return data
 
 
 def _require_timestamp_support() -> None:
@@ -207,12 +355,32 @@ def _push_update(
     """Thread-sicheres Pushen eines Update-Events in den HA Event Loop."""
     if not hass or not entry_id:
         return
+
+    compact_data = _compact_event_data(data_type, data)
     payload = {
         "domain": DOMAIN,
         "entry_id": entry_id,
         "data_type": data_type,
-        "data": data,
+        "data": compact_data,
     }
+
+    payload_size = _estimate_event_size(payload)
+    if payload_size > EVENT_DATA_MAX_BYTES:
+        _LOGGER.warning(
+            (
+                "Event payload for %s exceeds recorder limit (%d > %d bytes). "
+                "Content was compacted but will still be dropped by the recorder."
+            ),
+            data_type,
+            payload_size,
+            EVENT_DATA_MAX_BYTES,
+        )
+    elif payload_size > (EVENT_DATA_MAX_BYTES - _EVENT_SIZE_MARGIN):
+        _LOGGER.debug(
+            "Event payload for %s is close to recorder limit (%d bytes)",
+            data_type,
+            payload_size,
+        )
     try:
         # Direkter thread-sicherer Aufruf der synchronen fire-Methode
         hass.loop.call_soon_threadsafe(hass.bus.fire, EVENT_PANELS_UPDATED, payload)
@@ -942,19 +1110,31 @@ class _SyncRunner:
                     "(fetch_live_portfolios lieferte keine Daten)"
                 )
             else:
+                filtered_values = portfolio_values
+                if self.changed_portfolios:
+                    filtered_values = [
+                        row
+                        for row in portfolio_values
+                        if row.get("uuid") in self.changed_portfolios
+                    ]
+                    if not filtered_values:
+                        _LOGGER.debug(
+                            "sync_from_pclient: Keine Treffer für changed_portfolios "
+                            "→ sende komplette Aggregation (%d Portfolios)",
+                            len(portfolio_values),
+                        )
+                        filtered_values = portfolio_values
+
                 _push_update(
                     self.hass,
                     self.entry_id,
                     "portfolio_values",
-                    {
-                        "portfolios": portfolio_values,
-                        "changed_portfolios": list(self.changed_portfolios),
-                    },
+                    filtered_values,
                 )
                 _LOGGER.debug(
                     "sync_from_pclient: 📡 portfolio_values-Event gesendet "
                     "(%d Portfolios)",
-                    len(portfolio_values),
+                    len(filtered_values),
                 )
         except Exception:
             _LOGGER.exception(

--- a/tests/panel_event_payload.yaml
+++ b/tests/panel_event_payload.yaml
@@ -8,12 +8,10 @@ entry_id: 01JXT49AXKDAX0811MTMJXHG5G
 data_type: portfolio_values
 data:
   - uuid: 2cff58d9-ea39-4bb3-a6bb-3b170e4237ff
-    name: S-Broker
     position_count: 45
     current_value: 50000.00
     purchase_sum: 40000.00
   - uuid: f9996e0d-743d-417f-b0f2-150dd68df646
-    name: IBKR Portfolio
     position_count: 2
     current_value: 1000.00
     purchase_sum: 500.00


### PR DESCRIPTION
## Summary
- compact panels_updated event payloads before firing to stay under the recorder limit
- limit file-sync portfolio events to changed rows and keep payload structure consistent
- document the leaner payload format and cover the compaction helpers with tests

## Testing
- pytest tests/test_sync_from_pclient.py

------
https://chatgpt.com/codex/tasks/task_e_68d7fb823dcc8330a0699d6d76539dd1