### PR TITLE
Add gain metrics to live portfolio payloads

### DIFF
--- a/custom_components/pp_reader/data/coordinator.py
+++ b/custom_components/pp_reader/data/coordinator.py
@@ -124,11 +124,16 @@ def _portfolio_contract_entry(
     current_value = round(_normalize_amount(current_value_raw), 2)
     purchase_sum = round(_normalize_amount(purchase_sum_raw), 2)
 
+    gain_abs = round(current_value - purchase_sum, 2)
+    gain_pct = round((gain_abs / purchase_sum * 100) if purchase_sum else 0.0, 2)
+
     return portfolio_uuid, {
         "name": entry.get("name"),
         "value": current_value,
         "count": position_count,
         "purchase_sum": purchase_sum,
+        "gain_abs": gain_abs,
+        "gain_pct": gain_pct,
     }
 
 

--- a/custom_components/pp_reader/data/db_access.py
+++ b/custom_components/pp_reader/data/db_access.py
@@ -406,11 +406,19 @@ def _normalize_portfolio_row(row: sqlite3.Row) -> dict[str, Any]:
         except (TypeError, ValueError):
             return 0.0
 
+    current_value = _cent_to_eur(row["current_value"])
+    purchase_sum = _cent_to_eur(row["purchase_sum"])
+
+    gain_abs = round(current_value - purchase_sum, 2)
+    gain_pct = round((gain_abs / purchase_sum * 100) if purchase_sum > 0 else 0.0, 2)
+
     return {
         "uuid": row["uuid"],
         "name": row["name"],
-        "current_value": _cent_to_eur(row["current_value"]),
-        "purchase_sum": _cent_to_eur(row["purchase_sum"]),
+        "current_value": current_value,
+        "purchase_sum": purchase_sum,
+        "gain_abs": gain_abs,
+        "gain_pct": gain_pct,
         "position_count": row["position_count"]
         if row["position_count"] is not None
         else 0,
@@ -428,6 +436,8 @@ def fetch_live_portfolios(db_path: Path) -> list[dict[str, Any]]:
             "name": <str>,
             "current_value": <float>,    # EUR (2 Nachkommastellen)
             "purchase_sum": <float>,     # EUR (2 Nachkommastellen)
+            "gain_abs": <float>,         # EUR (2 Nachkommastellen)
+            "gain_pct": <float>,         # % (2 Nachkommastellen)
             "position_count": <int>
           },
           ...

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -148,11 +148,18 @@ def _normalize_portfolio_value_entry(item: Mapping[str, Any]) -> dict[str, Any] 
         except (TypeError, ValueError):
             return 0
 
+    current_value = _float("current_value", "value")
+    purchase_sum = _float("purchase_sum")
+    gain_abs = round(current_value - purchase_sum, 2)
+    gain_pct = round((gain_abs / purchase_sum * 100) if purchase_sum else 0.0, 2)
+
     return {
         "uuid": str(uuid),
         "position_count": _int("position_count", "count"),
-        "current_value": _float("current_value", "value"),
-        "purchase_sum": _float("purchase_sum"),
+        "current_value": current_value,
+        "purchase_sum": purchase_sum,
+        "gain_abs": gain_abs,
+        "gain_pct": gain_pct,
     }
 
 

--- a/tests/panel_event_payload.yaml
+++ b/tests/panel_event_payload.yaml
@@ -11,10 +11,14 @@ data:
     position_count: 45
     current_value: 50000.00
     purchase_sum: 40000.00
+    gain_abs: 10000.00
+    gain_pct: 25.0
   - uuid: f9996e0d-743d-417f-b0f2-150dd68df646
     position_count: 2
     current_value: 1000.00
     purchase_sum: 500.00
+    gain_abs: 500.00
+    gain_pct: 100.0
 
 # --- portfolio_positions (ein Portfolio) ---
 # domain: pp_reader

--- a/tests/test_sync_from_pclient.py
+++ b/tests/test_sync_from_pclient.py
@@ -141,6 +141,8 @@ def test_compact_event_data_trims_portfolio_values_list() -> None:
             "position_count": 3,
             "current_value": 1234.57,
             "purchase_sum": 1100.0,
+            "gain_abs": 134.57,
+            "gain_pct": 12.23,
         }
     ]
 
@@ -170,6 +172,8 @@ def test_compact_event_data_trims_portfolio_values_mapping() -> None:
             "position_count": 1,
             "current_value": 200.99,
             "purchase_sum": 199.0,
+            "gain_abs": 1.99,
+            "gain_pct": pytest.approx(1.0, rel=0, abs=0.01),
         }
     ]
 


### PR DESCRIPTION
## Summary
- calculate gain_abs and gain_pct alongside current values when reading portfolio snapshots
- include the gain metrics in price-cycle event payloads and websocket compaction helpers
- extend the test fixture payloads to assert the newly exposed gain fields

## Testing
- pytest tests/test_sync_from_pclient.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d81266c6ec8330ab7bc842349cb7f0