### PR TITLE
Recalculate live portfolio totals after price updates

### DIFF
--- a/tests/prices/test_price_service.py
+++ b/tests/prices/test_price_service.py
@@ -21,6 +21,7 @@ import logging
 import re
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -566,6 +567,120 @@ async def test_normal_batch(monkeypatch, tmp_path):
 
     # Keine doppelten portfolio_values
     assert sum(1 for k, _ in pushed if k == "portfolio_values") == 1
+
+
+@pytest.mark.asyncio
+async def test_price_update_refreshes_portfolio_gains(monkeypatch, tmp_path):
+    """A price change updates portfolio gains alongside the value payload."""
+
+    db_path = tmp_path / "portfolio_refresh.db"
+    initialize_database_schema(db_path)
+
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO portfolios (uuid, name) VALUES (?, ?)",
+            ("pf-refresh", "Refresh Depot"),
+        )
+        conn.execute(
+            """
+            INSERT INTO securities (
+                uuid, name, ticker_symbol, currency_code, retired, last_price,
+                last_price_source
+            ) VALUES (?, ?, ?, ?, 0, ?, ?)
+            """,
+            (
+                "sec-refresh",
+                "Refresh Equity",
+                "REF",
+                "EUR",
+                int(100 * 1e8),
+                "yahoo",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO transactions (
+                uuid, type, portfolio, date, currency_code, amount, shares, security
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "tx-refresh",
+                0,
+                "pf-refresh",
+                "2024-01-01",
+                "EUR",
+                100_000,
+                int(10 * 1e8),
+                "sec-refresh",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO portfolio_securities (
+                portfolio_uuid, security_uuid, current_holdings, purchase_value, current_value
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            ("pf-refresh", "sec-refresh", 10.0, 100_000, 100_000),
+        )
+        conn.commit()
+
+    hass = FakeHass()
+    entry_id = "entry_refresh"
+    _init_store(hass, entry_id, db_path, {"REF": ["sec-refresh"]})
+
+    async def _fake_revaluation(hass_, conn, updated_security_uuids):
+        return {"portfolio_values": None, "portfolio_positions": None}
+
+    monkeypatch.setattr(
+        "custom_components.pp_reader.prices.revaluation.revalue_after_price_updates",
+        _fake_revaluation,
+    )
+
+    def _fake_fetch_positions_for_portfolios(db_path_, portfolio_ids):
+        return {}
+
+    monkeypatch.setattr(
+        "custom_components.pp_reader.prices.price_service.fetch_positions_for_portfolios",
+        _fake_fetch_positions_for_portfolios,
+    )
+
+    pushed: list[tuple[str, Any]] = []
+
+    def _fake_push_update(hass_, entry_id_, data_type, payload):
+        pushed.append((data_type, payload))
+
+    monkeypatch.setattr(price_service, "_push_update", _fake_push_update)
+
+    async def _fake_fetch(self, symbols):
+        assert symbols == ["REF"]
+        return {"REF": _make_quote("REF", 120.0, "EUR")}
+
+    monkeypatch.setattr(YahooQueryProvider, "fetch", _fake_fetch)
+
+    await _run_price_cycle(hass, entry_id)
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cur = conn.execute(
+            """
+            SELECT current_value FROM portfolio_securities
+            WHERE portfolio_uuid=? AND security_uuid=?
+            """,
+            ("pf-refresh", "sec-refresh"),
+        )
+        updated_current_value = cur.fetchone()[0]
+
+    assert updated_current_value == 120_000
+
+    pv_events = [payload for kind, payload in pushed if kind == "portfolio_values"]
+    assert pv_events, "portfolio_values Event erwartet"
+
+    payload = pv_events[0]
+    assert isinstance(payload, list)
+    refresh_entry = next(item for item in payload if item["uuid"] == "pf-refresh")
+    assert refresh_entry["current_value"] == pytest.approx(1200.0)
+    assert refresh_entry["purchase_sum"] == pytest.approx(1000.0)
+    assert refresh_entry["gain_abs"] == pytest.approx(200.0)
+    assert refresh_entry["gain_pct"] == pytest.approx(20.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- recalculate impacted `portfolio_securities` rows when live prices change so holdings/purchase/current values stay in sync
- reuse the refreshed portfolio list for fallback aggregation to ensure emitted portfolio gain figures are up to date
- add a regression test covering gain updates when a price change occurs

## Testing
- PYTHONPATH=. pytest tests/prices/test_price_service.py::test_price_update_refreshes_portfolio_gains

------
https://chatgpt.com/codex/tasks/task_e_68d81fb332f083308e6cdb535ec4888e