### PR TITLE
Fix account table selectors in portfolio updates

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
@@ -185,12 +185,33 @@ export function handlePortfolioUpdate(update, root) {
 
   // Total-Wealth neu berechnen (Accounts + Portfolios)
   try {
-    const eurTable = root.querySelector('.accounts-eur-table table');
-    const fxTable = root.querySelector('.accounts-fx-table table');
+    const findTable = (...selectors) => {
+      for (const selector of selectors) {
+        if (!selector) continue;
+        const tableEl = root?.querySelector(selector);
+        if (tableEl) return tableEl;
+      }
+      return null;
+    };
+
+    const eurTable = findTable(
+      '.account-table table',
+      '.accounts-eur-table table',
+      '.accounts-table table'
+    );
+    const fxTable = findTable(
+      '.fx-account-table table',
+      '.accounts-fx-table table'
+    );
 
     const extractAccounts = (tbl, isFx) => {
       if (!tbl) return [];
-      return Array.from(tbl.querySelectorAll('tbody tr.account-row')).map(r => {
+      const accountRows = tbl.querySelectorAll('tbody tr.account-row');
+      const rows = accountRows.length
+        ? Array.from(accountRows)
+        : Array.from(tbl.querySelectorAll('tbody tr:not(.footer-row)'));
+
+      return rows.map(r => {
         const cell = isFx ? r.cells[2] : r.cells[1];
         return { balance: parseNumLoose(cell?.textContent) };
       });


### PR DESCRIPTION
## Summary
- update the portfolio event handler to locate the current account tables rendered by overview.js
- fall back to non-classed account rows so balance parsing keeps working with newer markup

## Testing
- Simulated a portfolio_values event in a linkedom DOM harness to confirm the header keeps the account balances

------
https://chatgpt.com/codex/tasks/task_e_68d82e75424c833089352427f14ff000