### PR TITLE
Update architecture documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,563 +1,374 @@
-# ARCHITEKTUR-DOKUMENTATION – Portfolio Performance Reader (pp_reader)
+# Architecture – Portfolio Performance Reader (`pp_reader`)
 
-## Inhaltsverzeichnis
-1. [Überblick](#überblick)
-2. [Externe Abhängigkeiten (Packages)](#externe-abhängigkeiten-packages)
-3. [Interne Modulstruktur](#interne-modulstruktur)
-4. [Home Assistant Integration](#home-assistant-integration)
-5. [Daten & Persistenz](#daten--persistenz)
-6. [Domänenmodell](#domänenmodell)
-7. [Control Flow & Datenfluss](#control-flow--datenfluss)
-8. [Schnittstellen](#schnittstellen)
-9. [Konfiguration](#konfiguration)
-10. [Fehlerbehandlung & Beobachtbarkeit](#fehlerbehandlung--beobachtbarkeit)
-11. [Leistung & Nebenläufigkeit](#leistung--nebenläufigkeit)
-12. [Sicherheit](#sicherheit)
-13. [Teststrategie](#teststrategie)
-14. [Erweiterbarkeit & Architektur-Entscheidungen](#erweiterbarkeit--architektur-entscheidungen)
-15. [Bekannte Lücken/Schulden](#bekannte-lückenschulden)
-16. [Glossar](#glossar)
-17. [Abdeckungs-Checkliste](#abdeckungs-checkliste)
+## Table of contents
+1. [Overview](#overview)
+2. [Code structure](#code-structure)
+3. [External dependencies & services](#external-dependencies--services)
+4. [Home Assistant integration layer](#home-assistant-integration-layer)
+5. [Configuration](#configuration)
+6. [Data ingestion & persistence](#data-ingestion--persistence)
+7. [Price service](#price-service)
+8. [Foreign exchange helper](#foreign-exchange-helper)
+9. [WebSocket API & frontend](#websocket-api--frontend)
+10. [Domain model snapshot](#domain-model-snapshot)
+11. [Control flow summary](#control-flow-summary)
+12. [Error handling & observability](#error-handling--observability)
+13. [Performance & concurrency](#performance--concurrency)
+14. [Security & data handling](#security--data-handling)
+15. [Testing strategy](#testing-strategy)
+16. [Extensibility & architectural decisions](#extensibility--architectural-decisions)
+17. [Known gaps & open questions](#known-gaps--open-questions)
+18. [Glossary](#glossary)
 
----
-
-## Überblick
-Der Home Assistant Custom Component `pp_reader` (Domain: `pp_reader`) integriert Portfolio- und Finanzdaten aus einer lokalen Portfolio Performance (`.portfolio`) Datei in Home Assistant.
-Hauptziele:
-- Periodisches Einlesen & Synchronisieren strukturierter Finanzdaten (Konten, Depots, Wertpapiere, Transaktionen).
-- Persistenz in einer SQLite-Datenbank für schnelle Aggregationen.
-- Bereitstellung von Sensoren und eines benutzerdefinierten Dashboards (Web Component + inkrementelle Updates via WebSocket Events).
-- Live-Preisaktualisierung (Yahoo Finance via `yahooquery`) mit minimal-invasiver Aktualisierung nur geänderter Kurse und partieller Revaluation betroffener Portfolios.
-
-Wichtigste Anwendungsfälle:
-- Anzeige aktueller Kontostände und Depotwerte in HA.
-- Drilldown in Depot-Positionen (Lazy Load).
-- Automatische Neuberechnung bei Dateiänderungen (Change Detection per mtime).
-- Optionale zyklische Marktpreis-Updates (nur letzter Preis, keine Historie).
-- Backup & Wiederherstellung der SQLite-Datenbank.
-
-High-Level Architektur:
-Die Architektur besteht aus:
-- Import- & Sync-Schicht (Parsing Protobuf → SQLite Sync).
-- Datenhaltung (SQLite Schema, Backup Mechanismus).
-- Berechnungslogik (Aggregation, Kennzahlen).
-- Integration Layer (Coordinator, WebSockets, Events).
-- Frontend Panel (Shadow DOM, inkrementelles Patchen).
-- Preis-Service (Orchestrator + Provider-Abstraktion).
 <!-- DIAGRAMS-PLACEHOLDER -->
 
 ---
 
-## Externe Abhängigkeiten (Packages)
-Quellen:
-- `requirements.txt` (Root)
-- `custom_components/pp_reader/manifest.json` (Runtime für HA Integration)
+## Overview
+The custom component `pp_reader` integrates a local Portfolio Performance (`.portfolio`) file into Home Assistant. The integration:
 
-| Paket | Version (manifest/req) | Rolle | Verwendung (Module) |
-|-------|------------------------|-------|----------------------|
-| homeassistant | 2025.2.4 (requirements.txt) | Host-Framework | Plattform, Config Flow, Entities |
-| protobuf | >=4.25.0 | Protobuf Deserialisierung | `data/reader.py`, `name/abuchen/portfolio/client_pb2.*` |
-| pandas | >=2.2.0 | (Potentielle Aggregation / evtl. Historik) | Noch nicht prominent sichtbar (evtl. zukünftige Erweiterung) |
-| numpy | >=1.26.0 | Numerik | Potenziell für Berechnungen (kein direkter Code-Auszug gezeigt) |
-| yahooquery | 2.3.7 | Live-Preis Provider | `prices/` (Provider & Fetch Orchestrator) |
-| colorlog | 6.9.0 | Farbige Logs | Globales Logging |
-| ruff | 0.11.13 | Linting (Dev) | Entwicklungs-Tooling |
-| sqlite3 (Stdlib) | (System) | Persistenz | DB Zugriff in `data/*` |
-| asyncio (Stdlib) | - | Nebenläufigkeit | Preis-Orchestrator, Coordinator |
+- Parses Portfolio Performance protobuf data and mirrors it into a dedicated SQLite database that lives next to Home Assistant’s configuration.
+- Exposes account and portfolio information to Home Assistant sensors and a custom dashboard panel.
+- Schedules optional Yahoo Finance price updates via `yahooquery`, persists the last fetched quote, and triggers partial portfolio revaluation.
+- Provides an automated backup cycle and a debug service to create on-demand SQLite snapshots.
 
-Laufzeit- vs. Entwicklungs-Abhängigkeiten:
-- Dev: `ruff`, (Tooling / Lint).
-- Runtime: alle anderen (manifest.json definiert HA-relevante requirements; `homeassistant` selbst wird durch HA-Host normalerweise bereitgestellt—hier für Dev Container fixiert).
+Key responsibilities are split across five areas:
+
+1. **Home Assistant lifecycle** – config flow, setup, and entity registration.
+2. **Data ingestion** – file parsing, diff sync to SQLite, and aggregation helpers.
+3. **Price orchestration** – background task that updates quotes and triggers recalculations.
+4. **Foreign exchange** – on-demand loading and caching of EUR exchange rates when non-EUR accounts exist.
+5. **Presentation** – WebSocket API and dashboard assets for drill-down views.
 
 ---
 
-## Interne Modulstruktur
-Kompakter Verzeichnisüberblick (aus Repository-Stand):
+## Code structure
+Repository folders relevant for the runtime integration:
 
-```
+```text
 custom_components/pp_reader/
-  __init__.py              # HA Entry Points, Panel-Registrierung, Preis-Task Setup
-  const.py                 # Domain-Konstanten
-  config_flow.py           # Config- & OptionsFlow
-  manifest.json            # HA Manifest
-  sensor.py                # Sensor Setup Aggregator
-  sensors/                 # Einzelne Sensor-Klassen (Accounts, Depots, Gains ...)
+  __init__.py                # Integration entry points and scheduler wiring
+  manifest.json              # Home Assistant metadata and runtime requirements
+  const.py                   # Shared constants (domain, config keys)
+  config_flow.py             # Config flow and options flow implementation
+  sensor.py                  # Sensor platform bootstrap
+  services.yaml              # Service descriptions exposed to Home Assistant
+  currencies/
+    fx.py                    # Frankfurter FX helper (EUR conversions)
   data/
-    db_schema.py           # SQL DDL (Tabellen-Schema)
-    db_init.py             # Initialisierung ALL_SCHEMAS
-    db_access.py           # (implizit) CRUD / Query (Referenzen via Imports)
-    reader.py              # Protobuf Parsing (.portfolio)
-    coordinator.py         # DataUpdateCoordinator für File→DB Sync
-    sync_from_pclient.py   # Diff-Sync aus PClient in DB
-    websocket.py           # WebSocket Commands + Event Push Helpers
-    backup_db.py           # Backup & Integritätsprüfung
+    __init__.py
+    reader.py                # .portfolio parser (protobuf extraction)
+    sync_from_pclient.py     # File → SQLite diff synchronisation
+    db_schema.py             # CREATE TABLE definitions & indices
+    db_init.py               # Database bootstrap (executes ALL_SCHEMAS)
+    db_access.py             # Query helpers used by coordinator & WebSockets
+    coordinator.py           # DataUpdateCoordinator for sensor snapshots
+    websocket.py             # WebSocket commands & payload builders
+    backup_db.py             # Periodic backups + service registration
   logic/
-    accounting.py          # Aggregation Kontostände
-    portfolio.py           # Depot-Bewertungen
-    validators.py          # Datenvalidierung
+    accounting.py            # Account balance aggregation
+    portfolio.py             # Portfolio valuation helpers
+    securities.py            # Holdings aggregation utilities for prices
+    validators.py            # Data validation helpers used by accounting
   prices/
-    provider_base.py       # Provider-Protocol & Quote Dataclass
-    yahooquery_provider.py # Yahoo Finance Implementation (aus Doku referenziert)
-    price_service.py       # Orchestrator (Intervall, Lock, DB Updates, Events)
-    revaluation.py         # Partielle Revaluation nach Preisänderungen
-  www/pp_reader_dashboard/ # Frontend (Panel, JS, CSS)
-    panel.js               # Einstieg für Custom Panel
-    js/                    # Tabs, Data APIs, Update Handler
-    css/                   # Styles
-  translations/            # i18n Strings (en/de)
-  name/abuchen/portfolio/  # Generierte Protobuf Typen (.pyi)
+    price_service.py         # Price cycle orchestration and change detection
+    provider_base.py         # Provider protocol and Quote dataclass
+    yahooquery_provider.py   # Yahoo Finance implementation (yahooquery)
+    revaluation.py           # Partial portfolio revaluation after price changes
+    symbols.py               # Active symbol discovery from SQLite
+  sensors/
+    depot_sensors.py         # Portfolio value sensors
+    gain_sensors.py          # Gain sensors derived from other sensor data
+    purchase_sensors.py      # Purchase sum sensors
+  translations/              # HA UI strings (de/en)
+  www/pp_reader_dashboard/
+    panel.js                 # Registers <pp-reader-panel> custom panel
+    js/dashboard.js          # Dashboard behaviour & WebSocket usage
+    css/*.css                # Styling for panel layout
 ```
 
-Kurzbeschreibung Hauptmodule:
-
-| Modul | Zweck | Kern-Outputs | Abhängigkeiten |
-|-------|-------|--------------|----------------|
-| `data/reader.py` | Entpackt & parsed `.portfolio` ZIP/Protobuf | `PClient` Objekt | Protobuf Klassen |
-| `data/sync_from_pclient.py` | Diff-Synchronisation nach SQLite | DB Mutationen | `db_access`, `db_schema` |
-| `data/coordinator.py` | Taktung & Change Detection Datei (mtime) | `coordinator.data` Struktur (Accounts/Portfolios/Transactions/last_update) | `reader`, `sync_from_pclient`, Aggregationen |
-| `data/db_schema.py` | DDL Definition | SQL Statements | - |
-| `data/websocket.py` | WebSocket Commands (accounts, portfolios, positions, file update) | JSON Payloads / HA Events | HA websocket_api, db_access |
-| `prices/price_service.py` | Preis-Orchestrator (Lock, Scheduling) | Event-Push bei Änderungen | `provider_base`, `yahooquery_provider`, `revaluation` |
-| `prices/revaluation.py` | Partielle Neubewertung betroffener Portfolios | Dict mit `portfolio_values`, `portfolio_positions` | DB, Aggregationslogik |
-| `sensors/*` | HA Sensor Entities | HA State Updates | Coordinator Data |
-| `logic/accounting.py` | Kontostandsberechnungen (inkl. FX-Layer Hinweis) | Summen/Balances | DB Rows / FX |
-| `logic/portfolio.py` | Depot-Werte, Kauf-Summen | Aggregierte Werte | DB Rows |
-| `logic/validators.py` | Validierungslogik (Transaktionen etc.) | `ValidationResult` | DB & Protobuf Typen |
-| `www/...` | Frontend Dashboard mit inkrementellen Updates | DOM Patch | WebSocket Events |
-| `backup_db.py` | Backup Rotation & Integrität | Kopien der DB | SQLite, Filesystem |
-
-Konfigurations-/Verhaltens-Flags:
-- Preisintervall & Debug: OptionsFlow (`config_flow.py`).
-- FX Preload (aus Doku, Modul `currencies/fx.py` – nicht im Ausschnitt gezeigt, aber erwähnt).
-- Change Detection: mtime minute-truncation (Coordinator).
-- Preis-Live-Update: Lock + Skip bei Overlap.
+Support tooling lives outside of the integration (for example `scripts/`, `tests/`, `TESTING.md`).
 
 ---
 
-## Home Assistant Integration
-Manifest: `custom_components/pp_reader/manifest.json`
-Wesentliche Felder:
-```json
-{
-  "domain": "pp_reader",
-  "name": "Portfolio Performance Reader",
-  "version": "0.10.0",
-  "requirements": ["protobuf>=4.25.0","pandas>=2.2.0","numpy>=1.26.0","yahooquery==2.3.7"],
-  "iot_class": "local_polling",
-  "loggers": ["custom_components.pp_reader","custom_components.pp_reader.prices"]
-}
-```
+## External dependencies & services
 
-### Lifecycle Hooks
-| Hook | Ort | Funktion |
-|------|-----|----------|
-| `async_setup` | `__init__.py` | Statische Pfade registrieren, WebSocket Commands registrieren |
-| `async_setup_entry` | `__init__.py` | DB Schema init, Coordinator erstellen, Panel registrieren, Preis-Task initialisieren, Backup starten |
-| `async_unload_entry` | `__init__.py` | Tasks canceln, Cleanup state keys, Plattform entladen |
-| Reload Listener | `entry.add_update_listener` | Interval-/Debug-Änderungen anwenden |
+| Dependency | Source | Purpose | Notes |
+|------------|--------|---------|-------|
+| `homeassistant==2025.2.4` | `requirements.txt` | Development container baseline to run HA locally | Provided by HA core in production. |
+| `protobuf>=4.25.0` | `manifest.json` | Parse `.portfolio` protobuf payloads | Required for `data/reader.py`. |
+| `yahooquery==2.4.1` | `manifest.json` | Fetch latest quotes from Yahoo Finance | Depends on `lxml`; exposes a batch API used by the price service. |
+| `lxml>=5.2.1` | `manifest.json` | Ensures Python 3.13 compatible wheels for yahooquery | Pulled explicitly after build failures with older indirect pins. |
+| `pandas>=2.2.0`, `numpy>=1.26.0` | `manifest.json` | Reserved for future analytics and compatibility with upstream Portfolio Performance tooling | Currently not imported; retained to avoid breaking environments expecting them. |
+| `aiohttp` | Home Assistant core dependency | HTTP client for Frankfurter FX API | Used indirectly in `currencies/fx.py`. |
+| Frankfurter API (`https://api.frankfurter.app`) | Runtime service | Provides EUR exchange rates | Only queried when non-EUR accounts require conversions. |
+| Yahoo Finance | Runtime service via yahooquery | Provides market prices | Only last price is stored (no intraday history). |
 
-### `hass.data` Struktur (erweitert)
-Pro Config Entry:
+Developer tooling includes `ruff` and scripts under `scripts/` for linting and local Home Assistant startup.
+
+---
+
+## Home Assistant integration layer
+### Manifest
+`manifest.json` declares domain `pp_reader`, version `0.11.0`, the runtime dependencies above, and marks the integration as `local_polling` with a config flow.
+
+### Setup lifecycle
+
+- `async_setup` (`__init__.py`)
+  - Registers the dashboard static files under `/pp_reader_dashboard`.
+  - Registers WebSocket commands from `data.websocket`.
+
+- `async_setup_entry`
+  - Initializes the SQLite schema via `data.db_init.initialize_database_schema` for the configured database path.
+  - Creates and stores a `PPReaderCoordinator` instance (see [Data ingestion](#data-ingestion--persistence)).
+  - Forwards platforms (currently sensors only).
+  - Configures the price service state and starts the initial cycle if prices are enabled.
+  - Registers the backup system (`data.backup_db.setup_backup_system`).
+  - Registers the custom panel `<pp-reader-panel>` if it is not already active.
+
+- `async_unload_entry`
+  - Unloads sensor entities.
+  - Cancels the scheduled price interval task, removes `price_*` keys from `hass.data`, and clears domain state when the last entry unloads.
+
+### `hass.data` contract
+For each config entry `entry_id`, `hass.data[DOMAIN][entry_id]` stores:
+
 ```python
-hass.data["pp_reader"][entry_id] = {
-  "file_path": <str>,
-  "db_path": <Path>,
-  "coordinator": <PPReaderCoordinator>,
-  # Preis-Service State (per initialize_price_state):
-  "price_lock": asyncio.Lock(),
-  "price_task_cancel": <callable or handle>,
-  "price_error_counter": int,
-  "price_currency_drift_logged": set(),
-  # Weitere Caches (implizit möglich)
+{
+    "file_path": str,         # Source .portfolio file
+    "db_path": Path,          # SQLite database file
+    "coordinator": PPReaderCoordinator,
+    "price_lock": asyncio.Lock,
+    "price_task_cancel": Callable | None,
+    "price_interval_applied": int | None,
+    "price_error_counter": int,
+    "price_currency_drift_logged": set[str],
+    "price_empty_symbols_logged": bool,
+    "price_empty_symbols_skip_logged": bool,
+    "price_last_symbol_count": int,
+    "price_last_cycle_meta": dict[str, Any],
 }
 ```
-(Preis-spezifische Keys aus Dokumentation `.docs/nextGoals.md` / `.docs/DEV_PRICE_TODO.md` abgeleitet.)
 
-### Config Flow & Options Flow
-`config_flow.py`:
-- Schritte:
-  1. `user`: Eingabe `file_path`, Auswahl ob Default DB Pfad (`/config/pp_reader_data/<name>.db`).
-  2. Optional `db_path`: Benutzerdefiniertes Verzeichnis validieren → DB Datei wird benannt nach Portfolio-Datei-Stem.
-- Parsing-Validierung: `parse_data_portfolio` (Fehler → `parse_failed`).
-- OptionsFlow Felder:
-  - `price_update_interval_seconds` (≥300, Default 900).
-  - `enable_price_debug` (bool).
-- Reload übernimmt Änderungen (Logger-Level Anpassung für Namespace `custom_components.pp_reader.prices`).
+### Config flow & options flow
+- Config flow (`config_flow.PortfolioConfigFlow`)
+  - Step `user`: validate the `.portfolio` path and optionally choose to use the default database directory (`/config/pp_reader_data/<stem>.db`).
+  - Step `db_path`: allow a custom directory for the SQLite file when the default is not used.
+  - Validation relies on `data.reader.parse_data_portfolio` to ensure the file is readable.
+- Options flow exposes:
+  - `price_update_interval_seconds` (>=300 seconds, default 900).
+  - `enable_price_debug` to raise logger levels for the price namespace.
+  - Option changes trigger `_async_reload_entry_on_update`, rescheduling the interval and rerunning the initial cycle.
 
-### Sensoren
-`custom_components/pp_reader/sensor.py` + `sensors/*`:
-- Nutzen `CoordinatorEntity` (pull aus `coordinator.data`).
-- Rounding: 2 Dezimalstellen erst am Boundary.
-- Naming: slug aus UUID + semantischer Suffix (`_balance`, `_value`, `_purchase_sum`, `_gain_abs`, `_gain_pct`).
-- Keine direkte Polling-Schleife; rely on Coordinator Updates (1-Min File-Check + Events bei Preis-Updates).
-- Gain-Sensoren hängen von aktuellen Portfolio Werten (mögliche interne Abhängigkeit zu `PortfolioDepotSensor`).
+### Sensor platform
+`sensor.py` instantiates coordinator-based entities:
 
-### Events & WebSocket
-- HA Event `EVENT_PANELS_UPDATED` (laut Architektur-Notiz in `.github/copilot-instructions.md` und Beschreibungen); Payload-Typen:
-  - `accounts`
-  - `last_file_update`
-  - `portfolio_values`
-  - `portfolio_positions`
-- Reihenfolge bei Preisänderungen:
-  1. `portfolio_values`
-  2. pro betroffenes Portfolio `portfolio_positions`
-- WebSocket Commands (`data/websocket.py`):
-  - `pp_reader/get_dashboard_data`
-  - `pp_reader/get_accounts`
-  - `pp_reader/get_last_file_update`
-  - `pp_reader/get_portfolio_data`
-  - `pp_reader/get_portfolio_positions`
-- Frontend Lazy-Load von Positionen (`fetchPortfolioPositionsWS`) bei Expand.
+- `PortfolioAccountSensor` for each active account.
+- `PortfolioDepotSensor` and `PortfolioPurchaseSensor` per portfolio.
+- `PortfolioGainAbsSensor` and `PortfolioGainPctSensor` derived from the value/purchase sensors.
 
-### Custom Panel
-`www/pp_reader_dashboard/panel.js` lädt Web Component `<pp-reader-panel>` → Shadow DOM → `<pp-reader-dashboard>`.
-DOM-Patch über `updateConfigsWS.js` (Handlers: `handleAccountUpdate`, `handlePortfolioUpdate`, `handlePortfolioPositionsUpdate`, `handleLastFileUpdate`).
-Strikte DOM-Klassen/Attribute (z. B. `.portfolio-row[data-portfolio=UUID]`) → keine Voll-Render, inkrementelles Patchen.
-
----
-
-## Daten & Persistenz
-### Quellen
-- Primär: Portfolio Performance `.portfolio` Datei (ZIP mit Protobuf Content) → Parsing durch `data/reader.py`.
-- Live-Preise: YahooQuery (nur letzter Preis persistiert).
-
-### SQLite Schema
-Definiert in `data/db_schema.py`. Tabellen (Auszug):
-
-| Tabelle | Zweck | Wichtige Spalten |
-|---------|-------|------------------|
-| `accounts` | Konten-Stammdaten | uuid, name, currency_code, balance |
-| `securities` | Wertpapiere + Preisfelder | uuid, ticker_symbol, last_price (1e-8 Skala), last_price_source, last_price_fetched_at |
-| `portfolios` | Depotstammdaten | uuid, name, reference_account |
-| `portfolio_securities` | Bestände im Depot | portfolio_uuid, security_uuid, current_holdings, purchase_value, avg_price (generated), current_value |
-| `transactions` | Bewegungen | uuid, type, date, amount, shares, security |
-| `transaction_units` | Mehrwährungs-/FX-Einheiten | fx_rate_to_base, currency_code |
-| `historical_prices` | Historische Kurse (nur aus PP Datei) | security_uuid, date, close |
-| `plans`, `watchlists`, `taxonomies`, `dashboards` | Zusätzliche PP Entitäten | id/name/... (teils geringe Nutzung aktuell) |
-| `taxonomy_*` | Klassifikationen | classifications, assignments |
-| `plan_attributes`, `portfolio_attributes`, ... | Key-Value Erweiterungen | key, value |
-
-Live-Preis Erweiterungen (aus Schema Ausschnitt):
-```sql
-last_price INTEGER,           -- 10^-8 Skalierung
-last_price_date INTEGER,
-last_price_source TEXT,
-last_price_fetched_at TEXT    -- UTC 'YYYY-MM-DDTHH:MM:SSZ'
-```
-
-### Migrationsstrategie
-- Neue Spalten via `CREATE TABLE IF NOT EXISTS` (Idempotenz).
-- Änderungen (fehlende Spalten) lt. ToDo-Liste ggf. Try/Except ALTER (Dokumentation markiert das Item als erledigt).
-- `ALL_SCHEMAS` (in `db_init.py`, nicht im Auszug, aber konzeptionell) muss erweitert werden, sonst werden Tabellen nicht erzeugt → wichtiger Pitfall.
-
-### Backups
-`data/backup_db.py`:
-- Zeitgesteuerte Backups (Intervall nicht im Ausschnitt, aber Funktion `setup_backup_system` registriert Intervall).
-- Integritätsprüfung via `PRAGMA integrity_check`.
-- Speicherung in Unterverzeichnis `backups/` relativ zur DB (`BACKUP_SUBDIR`).
-
-### Caching
-- In-Memory:
-  - `coordinator.data` für Sensors & Panel.
-  - Preis-Service: `price_currency_drift_logged` Set, `price_error_counter`.
-  - Frontend: Positionscache `window.__ppReaderPortfolioPositionsCache`.
-
-### Invalidierung
-- File mtime (minute-truncated) → bei Änderung: parse + diff.
-- Preisänderungen → partielle Revaluation nur betroffener Portfolios.
-
----
-
-## Domänenmodell
-Zentrale Entitäten (Mapping Protobuf → DB → App):
-| Entität | Quelle | Kerneigenschaften | Hinweise |
-|---------|--------|------------------|----------|
-| Account | `PAccount` | uuid, name, currency, is_retired | Balance berechnet (Aggregation) |
-| Security | `PSecurity` | uuid, name, ticker_symbol, feed, currency_code, retired | Preisfelder skaliert |
-| Portfolio | `PPortfolio` | uuid, name, reference_account | Wert = Summe Positionen |
-| Position | (Derived) | holdings, purchase_value, current_value, gains | Aus Tabelle `portfolio_securities` |
-| Transaction | `PTransaction` | type, amount, shares, date, currency | Multi-Units via `transaction_units` |
-| HistoricalPrice | `PHistoricalPrice` / `PFullHistoricalPrice` | date, close, high, low | Nur aus Datei, keine Yahoo Persistenz |
-
-Invarianten / Regeln:
-- Preis-Skalierung: Alle externen Float-Preise → `int(round(price * 1e8))`.
-- Rounding: Python "Bankers Rounding" (Standard `round()`).
-- EUR-Konversion: FX Preload vor Cross-Currency Berechnungen (siehe Instruktions-Dokumentation).
-- Keine Mutationen existierender Coordinator-Key-Shapes (`accounts`, `portfolios`, `transactions`, `last_update`).
-
----
-
-## Control Flow & Datenfluss
-### 1. Initial Setup
-1. User konfiguriert Integration (Config Flow) → DB Pfad + Portfolio Datei.
-2. `async_setup_entry` init DB Schema, legt Coordinator & Preis-Service-State an.
-3. Sofortiger Initiallauf des Preis-Orchestrators (falls aktiv) + Panel-Registrierung.
-
-### 2. Periodische Datei-Synchronisation
-1. Coordinator `_async_update_data` jede Minute: prüft mtime (minute-truncation).
-2. Wenn geändert: parse (`reader.parse_data_portfolio`).
-3. Diff-Sync (`sync_from_pclient`): Upsert + harte Deletes (kein Soft Delete).
-4. Aggregationen (Konten, Portfolios, Transaktionen).
-5. Update `coordinator.data` + Event Push `accounts`, `portfolio_values` etc.
-
-### 3. Preiszyklus (Live-Preise)
-1. Lock prüfen (Overlap → Skip, Metadaten: `skipped_running=True`).
-2. Symbol-Autodiscovery (aktive/ nicht retired Wertpapiere mit `ticker_symbol`).
-3. Chunking (Größe 50) → sequential fetch via YahooQuery Provider.
-4. Filter: `price > 0`, Drift-Prüfung (einmalige WARN).
-5. Change Detection: nur geänderte `uuid`s persistieren.
-6. Partielle Revaluation (`revaluation.revalue_after_price_updates`).
-7. Event Reihenfolge: `portfolio_values` → je Portfolio `portfolio_positions`.
-
-### 4. Frontend Initial Load & Update
-1. Dashboard-Initialisierung ruft `pp_reader/get_accounts` sowie `pp_reader/get_portfolio_data`; letzteres nutzt serverseitig `fetch_live_portfolios` und liefert On-Demand aggregierte Depotwerte (inkl. Live-Preisen) ohne Client-Side Overrides.
-2. WebSocket Subscription empfängt Events.
-3. DOM-Patch erfolgt inkrementell über die Handler in `updateConfigsWS.js`; Summen (Header, Tabellen-Footer) lesen aktuelle Werte direkt aus dem DOM, ein Override-Cache ist nicht mehr beteiligt.
-4. Lazy Load: Bei Expand Portfolio → `pp_reader/get_portfolio_positions`.
-
-### Berechnungsmodell (On-Demand Aggregation)
-Dieser Abschnitt beschreibt das konsolidierte Berechnungsmodell nach Migration auf serverseitige On-Demand Aggregation.
-
-Ziele:
-- Single Source of Truth für Depot-Kennzahlen (value, purchase_sum, count) direkt aus der SQLite-Datenbank.
-- Eliminierung des ehemaligen client-seitigen Override-Caches (`__ppReaderPortfolioValueOverrides`).
-- Beibehaltung der bestehenden Event-Sequenzen und Sensor-Verträge ohne Änderung von Key-Namen oder Shapes.
-
-Komponenten:
-- On-Demand Helper [`fetch_live_portfolios`](custom_components/pp_reader/data/db_access.py): Aggregiert aktuelle Portfolio-Werte unter Nutzung persistierter Live-Preise (`securities.last_price` + Skalierung 1e-8) und fallback-Logik für fehlende Preise (bestehende gespeicherte Werte).
-- WebSocket Handler (`ws_get_portfolio_data`, `ws_get_dashboard_data` in [custom_components/pp_reader/data/websocket.py](custom_components/pp_reader/data/websocket.py)): Liefern beim Initial-Ladezyklus bereits die aktuellsten Aggregationen (kein Merge/Delta mehr nötig).
-- Revaluation Pfad (`revalue_after_price_updates` in [custom_components/pp_reader/prices/revaluation.py](custom_components/pp_reader/prices/revaluation.py)): Führt partielle Neubewertung betroffener Depots nach Preisänderungen durch und pusht Events in unveränderter Reihenfolge:
-  1. `portfolio_values`
-  2. pro betroffenes Depot `portfolio_positions`
-- Coordinator [`PPReaderCoordinator`](custom_components/pp_reader/data/coordinator.py): Lädt weiterhin periodisch Datei→DB Synchronisationsresultate und hält `coordinator.data["portfolios"]` für Sensoren (Legacy-Kompatibilität). Frontend-Initialdaten verwenden jedoch ausschließlich die On-Demand Aggregation.
-
-Unveränderte Aspekte:
-- Keine neuen Eventtypen oder Payload-Felder.
-- Rounding (2 Dezimal) erst an Frontend-/Sensor-Grenze.
-- Sensoren konsumieren weiterhin `coordinator.data` (Backward Compatibility).
-
-Nicht mehr vorhanden:
-- Client Override Cache (Setzen/Löschen/Anwenden entfällt).
-- Heuristiken zur Erkennung von Full-Sync vs. Delta im Frontend.
-
-Vorteile:
-- Konsistenz zwischen Reload des Dashboards und Laufzeit-Events.
-- Reduziertes UI-spezifisches State-Handling.
-- Klare Trennung: Sensoren (Snapshot) vs. Frontend (Live On-Demand).
-
-Risiken & Mitigation:
-- Potenzielle Performance-Kosten bei sehr großen Depots → Option für leichtes Mikro-Caching (≤5s) ist bewusst zurückgestellt, erst nach Messung.
-- Divergenz zwischen Coordinator-Snapshot und On-Demand Aggregation: Minimiert durch identische Aggregationsfunktionen und Nutzung derselben Preisdaten.
-
-Testing Implikationen:
-- Neue Tests verifizieren, dass WebSocket Antworten direkt Live-Werte reflektieren (siehe geplante Items in `.docs/TODO_updateGoals.md`).
-- Revaluation Tests müssen keine Anpassung erhalten, solange Event-Reihenfolge unverändert bleibt.
-
-### 5. Backup Cycle
-1. Zeitgesteuerte Ausführung → Integritätsprüfung → Kopie in `backups/`.
-2. Optionale Aufbewahrungslogik (implizit—Details nicht sichtbar; potenziell erweiterbar).
-
-### 6. Unload / Reload
-1. Unload: Cancel Tasks, Entferne `price_*` State Keys.
-2. Reload: Reinitialisiert Preisintervall & Debug Logging.
-
-Fehlerpfad: Exceptions im Sync → `UpdateFailed` (Coordinator) → HA Retry-Mechanismus.
-
----
-
-## Schnittstellen
-### Öffentliche (stabile) Python APIs (implizit genutzt)
-| Signatur (Kurz) | Zweck |
-|-----------------|-------|
-| `parse_data_portfolio(path) -> PClient | None` (`data/reader.py`) | Protobuf Parsing |
-| `PPReaderCoordinator` (`data/coordinator.py`) | Lebenszyklus & Data Contract |
-| `initialize_price_state(hass, entry_id, interval)` (`prices/price_service.py`) | Preiszyklus starten (aus Doku) |
-| `revalue_after_price_updates(hass, conn, updated_security_uuids) -> dict` | Partielle Revaluation |
-| `setup_backup_system(hass, db_path)` (`data/backup_db.py`) | Backup Scheduling |
-
-(Stabilität basiert auf zentraler Nutzung; formell keine „public API“ Kennzeichnung.)
-
-### WebSocket Commands
-| Type | Request Felder | Response Payload |
-|------|----------------|------------------|
-| `pp_reader/get_accounts` | `entry_id` | `{ accounts: [...] }` |
-| `pp_reader/get_portfolio_data` | `entry_id` | `{ portfolios: [...] }` |
-| `pp_reader/get_portfolio_positions` | `entry_id`, `portfolio_uuid` | `{ positions: [...] }` |
-| `pp_reader/get_last_file_update` | `entry_id` | `{ last_file_update: ISO8601 }` |
-| `pp_reader/get_dashboard_data` | `entry_id` | Kombi Accounts + Portfolios |
-
-Timeout/Retry: WebSocket folgt HA Standard (keine expliziten Retry-Wrapper hier).
-
-### Events
-| HA Event | Datenfelder | Auslöser |
-|----------|-------------|----------|
-| `EVENT_PANELS_UPDATED` | `{"entry_id":..., "type": <data_type>, "data": ...}` | `_push_update` (Datei-/Preisänderung) |
+Sensors read from the coordinator snapshot (`coordinator.data`) to remain compatible with existing Home Assistant entity contracts.
 
 ### Services
-In `translations/en.json` Service `trigger_backup_debug` dokumentiert – Implementierung (Service Registrierung) nicht im aktuellen Ausschnitt sichtbar. Mögliche Diskrepanz: Service existiert evtl. oder ist geplant.
+`data.backup_db.setup_backup_system` registers `pp_reader.trigger_backup_debug`. The service runs the same backup cycle that the periodic job executes (every six hours) and logs success or failures.
 
 ---
 
-## Konfiguration
-| Option | Quelle | Default | Validierung | Wirkung |
-|--------|--------|---------|-------------|---------|
-| `file_path` | Config Flow | - | Muss existierende Datei sein | Quelle Portfolio Daten |
-| `db_path` / default | Config Flow | `<DEFAULT_DB_DIR>/<stem>.db` | Verzeichnis muss existieren | Persistenz |
-| `price_update_interval_seconds` | Options Flow | 900 | ≥300 | Scheduling Preiszyklus |
-| `enable_price_debug` | Options Flow | False | bool | Logger Level Namespace Preise |
+## Configuration
 
-Weitere implizite Werte:
-- `DEFAULT_DB_DIR = /config/pp_reader_data`
-- Zeitformat für Persistenz & Events: `YYYY-MM-DDTHH:MM:SSZ` (UTC, ohne ms)
+| Option | Source | Default | Validation | Impact |
+|--------|--------|---------|------------|--------|
+| `file_path` | Config flow | — | Must point to an existing `.portfolio` file | Defines the data source. |
+| `db_path` | Config flow | `/config/pp_reader_data/<portfolio>.db` | Directory must exist and be writable | Defines SQLite storage location. |
+| `price_update_interval_seconds` | Options flow | 900 | Minimum 300 | Reschedules the recurring price fetch. |
+| `enable_price_debug` | Options flow | `false` | Boolean | Elevates price logger levels to DEBUG when set. |
 
-Credentials: Keine (externe API `yahooquery` ohne Schlüssel für Basisdaten).
+No credentials are required; Yahoo Finance quotes are public and the FX helper only fetches EUR rates.
 
 ---
 
-## Fehlerbehandlung & Beobachtbarkeit
-Strategien:
-- Datei-Sync Fehler → `UpdateFailed` (Retry durch HA).
-- Preis-Orchestrator: Broad Catch, zählt Fehler (`price_error_counter`), WARN bei wiederholtem Scheitern (>=3).
-- Currency Drift: Einmalige WARN pro Symbol (`price_currency_drift_logged`).
-- Overlap: DEBUG + Skip Flag.
-- Zero Quotes: Dedizierte WARN (dedupliziert ≤ alle 30min, laut Doku).
-- Watchdog >25s Laufzeit: WARN.
+## Data ingestion & persistence
+### Portfolio parsing and synchronization
+- `data.reader.parse_data_portfolio` extracts `data.portfolio` from the `.portfolio` ZIP, removes the `PPPBV1` prefix, and parses it into `client_pb2.PClient`.
+- `data.sync_from_pclient.sync_from_pclient` takes the protobuf payload and applies inserts/updates/deletes across SQLite tables. The function also updates metadata such as `last_file_update`.
 
-Logging Namespaces:
-- `custom_components.pp_reader`
-- `custom_components.pp_reader.prices.*`
+### Coordinator (`data.coordinator.PPReaderCoordinator`)
+- Polls every minute (minute-truncated file timestamp).
+- When the `.portfolio` file changes, re-parses the file and re-runs the diff sync within an executor.
+- After each refresh:
+  - Loads accounts (`db_access.get_accounts`) and transactions.
+  - Computes balances via `logic.accounting.calculate_account_balance` with validation from `logic.validators`.
+  - Loads portfolio aggregates via `db_access.fetch_live_portfolios`, which sums persisted purchase and current values and counts active positions.
+  - Stores a snapshot in `self.data` for sensors: `accounts`, `portfolios`, `transactions`, and `last_update` (ISO8601).
 
-Strukturierte INFO Zeile (Preis-Zyklus):
-```
-prices_cycle symbols=<N> batches=<B> returned=<R> changed=<C> errors=<E> duration=<ms> skipped_running=<bool>
-```
+### SQLite schema & helpers
+- Definitions live in `data.db_schema`. The integration maintains tables for accounts, securities, portfolios, transactions, transaction units, FX rates, and metadata. `ALL_SCHEMAS` and the additional `idx_portfolio_securities_portfolio` index are executed idempotently by `data.db_init.initialize_database_schema`.
+- `db_access.py` offers strongly typed dataclasses and helper queries (e.g., `get_portfolio_positions`, `get_last_file_update`, `get_all_portfolio_securities`). Monetary values are stored as integers (cents) or scaled integers (`last_price` × 1e8) to avoid floating-point drift.
 
-Keine dedizierten Metriken / Traces (keine Observability-Frameworks im Code ersichtlich).
-
----
-
-## Leistung & Nebenläufigkeit
-Mechanismen:
-- Coordinator im HA Event Loop (I/O Bound: SQLite, File mtime, Protobuf Parse via Executor bei Bedarf möglich).
-- Preis-Orchestrator: Sequenzielle Batches (CHUNK_SIZE=50), Minimierung externer Latenz.
-- Lock (`price_lock`) verhindert Überlappung.
-- Revaluation partiell (nur betroffene Portfolios) → begrenzte Berechnungsarbeit.
-- DB Nutzung: Einfache Indizes (`idx_transactions_security`, `idx_transaction_units_currency`) vorhanden.
-- Potenzielle Bottlenecks:
-  - Große `.portfolio` Datei Parse.
-  - Reihenfolge serieller YahooQuery Batches (Balance Latenz vs. Rate Limit).
-- Kein aggressives Caching für Positions-Join auf Serverseite (Frontend cached).
+### Backups
+`data.backup_db`:
+- Runs every six hours and on manual trigger.
+- Executes `PRAGMA integrity_check`; if the database fails the check, it tries to restore from the newest valid backup in `<db>/backups/`.
+- Applies a tiered cleanup strategy: keep seven daily and four weekly backups.
 
 ---
 
-## Sicherheit
-Aspekte:
-- Lokale Dateien: Portfolio & SQLite im Container (Zugriffskontrolle durch Host/HA).
-- Keine geheimen Tokens / API Keys (YahooQuery Basisscope).
-- Supply Chain: Fixierte Versionsabhängigkeiten (manifest.json).
-- Angriffsoberflächen:
-  - WebSocket Commands (nur lesend, validieren `entry_id`).
-  - Kein externer Schreib-Endpunkt.
-- Backup Kopien (potenziell sensible Finanzdaten) → Empfehlung: Dateisystemberechtigungen restriktiv gestalten (nicht im Code erzwungen).
+## Price service
+`prices.price_service` owns the recurring quote fetch:
+
+1. **State initialisation** – `initialize_price_state` seeds locks and counters in `hass.data`.
+2. **Scheduling** – `_schedule_price_interval` (called from `__init__.py`) uses `async_track_time_interval` to run `_run_price_cycle` at the configured cadence.
+3. **Symbol discovery** – `prices.symbols.load_active_security_symbols` queries active securities with tickers; `price_service.build_symbol_mapping` groups UUIDs by ticker for change fan-out.
+4. **Fetching quotes** – `_fetch_quotes` (within `yahooquery_provider`) loads batches (`CHUNK_SIZE` 50) with a 20 second timeout. Failures increment `price_error_counter` and eventually disable debug skip logging.
+5. **Change detection** – `_detect_price_changes` compares scaled prices and filters out unchanged or invalid values (`price <= 0`). Currency drift per symbol logs once per runtime.
+6. **Persistence** – Updated prices and metadata are written to `securities` in SQLite. The service maintains a watchdog (25s) and tracks consecutive errors (threshold 3) for observability.
+7. **Revaluation** – `prices.revaluation.revalue_after_price_updates` recalculates affected portfolios, leveraging helpers in `logic.portfolio` and `logic.securities` to recompute holdings and values.
+8. **Event push** – `_push_update` from `sync_from_pclient` is reused to dispatch `EVENT_PANELS_UPDATED` in Home Assistant. The order remains `portfolio_values` followed by `portfolio_positions` per affected UUID.
+
+When no symbols are available the service logs the condition once and skips the fetch without treating it as an error. Reloading an entry reinitializes state and immediately triggers a new price cycle.
 
 ---
 
-## Teststrategie
-Referenzen (ToDo-Doku `.docs/DEV_PRICE_TODO.md`):
-- Tests: `tests/prices/test_yahooquery_provider.py`, `tests/prices/test_price_service.py` (aufgeführt als erledigt).
-- Fokusfälle:
-  - Fehlerzähler Reset
-  - Null-/0-Preis Filter
-  - Chunk Fehler Toleranz
-  - Currency Drift Deduplikation
-  - Event-Push nur bei Änderungen
-- Lokales Ausführen:
-  - Virtuelle Umgebung via `./scripts/setup_container`
-  - HA Start: `./scripts/develop` oder `./scripts/codex_develop`
-  - (Test-Runner nicht direkt sichtbar; vermutlich `pytest` standard—Empfehlung: Ergänzung in README falls noch nicht vorhanden.)
+## Foreign exchange helper
+`currencies.fx` provides optional EUR exchange rate support when multi-currency accounts exist:
 
-Empfehlung (Erweiterbar):
-- Unit Tests für Aggregationen (`logic/accounting.py`, `logic/portfolio.py`).
-- Integration Tests: End-to-End (Dateiänderung → Sensorstate).
-- Frontend: Smoke-Test Panel Aufbau (derzeit fehlend).
+- Determines required currencies from Portfolio Performance data (`get_required_currencies`).
+- Uses the Frankfurter API to fetch missing rates for a given date and stores them in the `fx_rates` table.
+- Employs asyncio executors and retry logic to avoid SQLite write lock issues.
+- Exposes `get_exchange_rates`, `ensure_exchange_rates_for_dates`, and `load_latest_rates`, which are used from WebSocket handlers to populate FX information when returning account data.
+
+The FX helper is resilient to network failures (logs warnings and returns partial results) to avoid blocking the main coordinator.
 
 ---
 
-## Erweiterbarkeit & Architektur-Entscheidungen
-### Extension Points
-| Bereich | Mechanismus | Beschreibung |
-|---------|-------------|--------------|
-| Preis-Provider | `PriceProvider` Protocol (`prices/provider_base.py`) | Weitere Provider implementierbar |
-| Events | `_push_update` (WebSocket/Event Layer) | Zusätzliche Datentypen möglich (Regel: keine Mutation bestehender Payloads) |
-| Sensoren | Neue Klassen in `sensors/` | Nutzung `CoordinatorEntity` |
-| Schema | `db_schema.py` + `ALL_SCHEMAS` | Neue Tabellen/Spalten ergänzen |
+## WebSocket API & frontend
+`data.websocket` registers the following commands via `websocket_api`:
 
-### Wichtige Entscheidungen (ADR-Stil)
-| Entscheidung | Kontext | Konsequenz |
-|--------------|---------|------------|
-| Nur letzter Live-Preis persistiert | Minimierung DB & Scope | Keine intraday Historie / reduzierte Komplexität |
-| Partielle Revaluation | Performance | Schnelle UI Reaktion bei Preisänderungen |
-| Harte Deletes beim Sync | Datenkonsistenz vs. Wiederherstellung | Entfernte Entities verschwinden sofort (kein Soft-Recovery) |
-| Ereignis-Patch statt Full Render (Frontend) | Vermeidung Flicker, Performance | Komplexere DOM-Selektor Logik |
-| Bankers Rounding & 1e8 Skalierung | Finanzgenauigkeit | Einheitliche Darstellung / Vergleichbarkeit |
-| Overlap Skip statt Queue | Einfachheit | Potenziell ausgelassene Zyklen bei Dauerlast |
+| Command | Request fields | Response |
+|---------|----------------|----------|
+| `pp_reader/get_dashboard_data` | `entry_id` | Combined accounts, portfolios, transactions, and last file update snapshot. |
+| `pp_reader/get_accounts` | `entry_id` | Accounts plus FX metadata; triggers FX fetch when non-EUR accounts exist. |
+| `pp_reader/get_last_file_update` | `entry_id` | ISO8601 timestamp from metadata. |
+| `pp_reader/get_portfolio_data` | `entry_id` | Live portfolio aggregates using `fetch_live_portfolios`. |
+| `pp_reader/get_portfolio_positions` | `entry_id`, `portfolio_uuid` | Detailed positions including gains and holdings. |
 
----
+All commands default to the coordinator snapshot when live aggregation fails to keep the dashboard responsive.
 
-## Bekannte Lücken/Schulden
-| Bereich | Beschreibung | Auswirkung | Empfehlung |
-|---------|--------------|------------|-----------|
-| Service Doku vs. Implementierung | `trigger_backup_debug` in translations; Service-Registrierung nicht nachgewiesen | Inkonsistenz UI | Prüfen & ergänzen oder entfernen |
-| Fehlende Tests für Coordinator Aggregationen | Nicht dokumentiert | Risiko unerkannter Regressions | Unit Tests hinzufügen |
-| Fehlende Security Hardening Hinweise | Keine chmod / Zugriffskontrolle | Potenzielles Disclosure Risiko | README Sicherheitsabschnitt erweitern |
-| Kein formales Migrationsframework | Nur DDL Idempotenz | Edge Cases bei Schema-Änderungen | Lightweight Migration Layer |
-| Fehlende Frontend Tests | UI Regressions möglich | Niedrige Abdeckung | Cypress / Playwright Pipeline |
-| Abwesenheit FX Implementations-Auszug | Nur referenziert | Verständnislücke | Dokumentation FX Quelle ergänzen |
-| Keine Rate-Limit Strategie für Preise | Provider-Limits unklar | Evtl. Blockierung | Adaptive Intervalle (Future) |
-| Diagramme fehlen | Geplant | Geringere Onboarding Geschwindigkeit | Nachreichen (Anker vorhanden) |
+The custom panel lives under `www/pp_reader_dashboard`:
 
-Verweis auf Diagramm-Placeholder: <!-- DIAGRAMS-PLACEHOLDER -->
+- `panel.js` registers `<pp-reader-panel>` and boots the dashboard when the sidebar item is opened.
+- `js/dashboard.js` opens a WebSocket connection, subscribes to `EVENT_PANELS_UPDATED`, and performs DOM updates without full re-rendering. Portfolio positions are lazily requested and cached in `window.__ppReaderPortfolioPositionsCache`.
+- CSS files (`base.css`, `cards.css`, `nav.css`) provide layout styling.
+
+Events emitted by `_push_update` follow the same contract as sensor snapshots, allowing the frontend to patch the DOM incrementally.
 
 ---
 
-## Glossar
-| Begriff | Definition |
-|---------|-----------|
-| Coordinator | HA `DataUpdateCoordinator` zur periodischen Aktualisierung |
-| Revaluation | Partielle Neubewertung nach Preisänderung |
-| Drift (Currency Drift) | Abweichung zwischen persistierter Währung & Quote-Währung |
-| Portfolio (Depot) | Sammlung von Positionen (Wertpapieren) |
-| Position | Bestand (Holdings) eines Wertpapiers im Depot |
-| Quote | Laufzeit-Preisobjekt eines Symbols (inkl. Metadaten) |
-| Event Patch | Inkrementelle DOM-Aktualisierung auf Frontend ohne Re-Render |
-| Overlap Skip | Mechanismus zur Vermeidung paralleler Preiszyklen |
-| Diff-Sync | Upsert + harte Delete von entfallenen Entities (Datei→DB) |
-| FX Preload | Vorab Laden von Wechselkursen zur EUR-Konversion |
-| Lazy Load | Datenabruf (z. B. Positionen) erst bei Bedarf (UI Expand) |
+## Domain model snapshot
+Key entities and their origin:
+
+| Entity | Source | Important fields | Notes |
+|--------|--------|------------------|-------|
+| Account | SQLite `accounts` + transactions | `uuid`, `name`, `currency_code`, `balance` (cents) | Balances are recomputed per refresh, not stored. |
+| Security | SQLite `securities` | `uuid`, `name`, `ticker_symbol`, `currency_code`, `last_price` (scaled) | `last_price_source` and `last_price_fetched_at` updated by price service. |
+| Portfolio | SQLite `portfolios` | `uuid`, `name`, `reference_account`, `is_retired` | Aggregates are derived from `portfolio_securities`. |
+| PortfolioSecurity | SQLite `portfolio_securities` | `current_holdings`, `purchase_value`, `current_value` (cents) | Generated `avg_price` column simplifies average cost lookup. |
+| Transaction | SQLite `transactions` | `type`, `amount`, `currency_code`, `shares`, `security` | `transaction_units` store FX amounts for cross-currency transfers. |
+| FXRate | SQLite `fx_rates` | `date`, `currency`, `rate` | Populated on demand via `currencies.fx`. |
+| Metadata | SQLite `metadata` | `last_file_update` | Drives coordinator sync decisions.
 
 ---
 
-## Abdeckungs-Checkliste
-| Kapitel | Erfüllt |
-|---------|---------|
-| Überblick | ✅ |
-| Externe Abhängigkeiten | ✅ |
-| Interne Modulstruktur | ✅ |
-| Home Assistant Integration | ✅ |
-| Daten & Persistenz | ✅ |
-| Domänenmodell | ✅ |
-| Control Flow & Datenfluss | ✅ |
-| Schnittstellen | ✅ |
-| Konfiguration | ✅ |
-| Fehlerbehandlung & Beobachtbarkeit | ✅ |
-| Leistung & Nebenläufigkeit | ✅ |
-| Sicherheit | ✅ |
-| Teststrategie | ✅ |
-| Erweiterbarkeit & Architektur-Entscheidungen | ✅ |
-| Bekannte Lücken/Schulden | ✅ |
-| Glossar | ✅ |
-| Diagramm-Placeholder vorhanden | ✅ |
+## Control flow summary
+1. **Initial setup** – Config flow validates file; setup entry initialises schema, coordinator, price state, backup scheduling, and panel registration.
+2. **Periodic sync** – Every minute the coordinator checks the `.portfolio` file mtime (rounded to the nearest minute). On change it parses, syncs to SQLite, reloads aggregates, and updates `coordinator.data`.
+3. **Price cycle** – According to the options flow interval, the price service locks execution, fetches Yahoo quotes, writes updated prices, runs revaluation, and publishes events.
+4. **Frontend interactions** – The dashboard uses WebSocket commands to fetch initial data and listens for `EVENT_PANELS_UPDATED` to patch rows. Portfolio positions are fetched lazily per user interaction.
+5. **Backups** – A 6-hour interval backup ensures integrity and retention; manual trigger is available via service call.
 
 ---
 
-_Ende der ARCHITEKTUR-DOKUMENTATION._
+## Error handling & observability
+- **Coordinator** – Wraps sync logic in try/except and raises `UpdateFailed` for Home Assistant to retry. Detailed logs highlight parse or SQLite issues.
+- **Price service** – Tracks consecutive errors, logs warnings for skipped runs, zero quotes, currency drift, and long cycles (>25s). On repeated failures it continues scheduling but keeps counters for visibility.
+- **WebSocket** – Falls back to coordinator snapshots on aggregation errors and sends `not_found` errors when an entry id is unknown.
+- **Backup system** – Logs success (`✅`) and failure (`❌`) with clear emoji markers; attempts recovery from the latest valid backup when integrity fails.
+- **Logging namespaces** – `custom_components.pp_reader` and `custom_components.pp_reader.prices*` allow focused log level control via the options flow.
+
+No metrics or traces are emitted; observability relies on structured log lines.
+
+---
+
+## Performance & concurrency
+- File parsing and SQLite operations run in executor threads to keep the event loop responsive.
+- `asyncio.Lock` ensures only one price cycle executes at a time; overlapping schedules are skipped rather than queued.
+- Quote fetches batch up to 50 symbols to balance throughput and rate limits.
+- Portfolio aggregation relies on SQL sums and the `idx_portfolio_securities_portfolio` index to speed up repeated queries.
+- FX writes use a threading lock and retry with exponential backoff to avoid SQLite `database is locked` errors.
+
+Potential bottlenecks: very large `.portfolio` files (protobuf parsing) and slow Yahoo responses. The system tolerates these by logging and skipping cycles rather than blocking the coordinator.
+
+---
+
+## Security & data handling
+- The integration only reads local files specified by the user and writes to SQLite in the configured directory. Ensure Home Assistant file permissions protect `.portfolio`, `.db`, and backup files because they contain financial data.
+- No API keys are stored; Yahoo quotes and Frankfurter FX endpoints are public.
+- WebSocket commands are read-only and scoped to the config entry id provided by Home Assistant.
+- Backups retain historical account information—consider external rotation if disk usage is a concern.
+
+---
+
+## Testing strategy
+Automated tests live under `tests/` (see [TESTING.md](TESTING.md)):
+
+- `tests/prices/` covers yahooquery integration, price cycle behaviours, and error counters.
+- `test_fetch_live_portfolios.py` and `test_ws_portfolios_live.py` validate the on-demand aggregation contract and WebSocket payloads.
+- `test_ws_accounts_fx.py` ensures FX rate hooks respond correctly when non-EUR accounts are present.
+- `test_currencies_fx.py` covers Frankfurter fetches, retries, and SQLite persistence.
+- `test_sync_from_pclient.py` verifies the diff sync for Portfolio Performance payloads.
+- `test_validators_timezone.py` guards transaction validation edge cases.
+
+Manual testing relies on the scripts in `scripts/` (`./scripts/develop`, `./scripts/lint`) and the Home Assistant dev container described in [README.md](README.md).
+
+---
+
+## Extensibility & architectural decisions
+
+| Decision | Context | Consequence |
+|----------|---------|-------------|
+| Persist only the latest quote | Keeps database lean and avoids stale history | Historical analytics require external tooling. |
+| Use partial revaluation after price changes | Reduces processing time after each quote update | Ensures timely UI updates without reprocessing all portfolios. |
+| Keep coordinator snapshots for sensors | Maintains backward compatibility with Home Assistant entity contracts | WebSocket layer consumes live aggregation to avoid double bookkeeping. |
+| Skip overlapping price cycles | Simplifies scheduling | Fast consecutive intervals may drop runs when the previous cycle is still executing. |
+| Store monetary values as integers | Ensures deterministic rounding | Formatting to two decimals happens in sensors/frontend. |
+| Explicitly depend on `lxml>=5.2.1` | Avoids wheel compatibility issues in development containers | Slightly increases package footprint but stabilises builds. |
+
+Extension points:
+
+- Implement additional price providers by extending `prices.provider_base.PriceProvider` and wiring them into `price_service`.
+- Add new entities by creating sensor classes under `sensors/` that consume the coordinator snapshot.
+- Extend the database schema by appending SQL statements to `ALL_SCHEMAS` (idempotent) and exposing new query helpers in `db_access`.
+- Enhance the dashboard by updating assets in `www/pp_reader_dashboard` and adjusting WebSocket payloads (preserving backward compatibility where possible).
+
+---
+
+## Known gaps & open questions
+- **Pandas / NumPy usage** – Manifest requires these packages although the current codebase does not import them. They appear to be held for future analytics or compatibility; confirm whether they can move to optional extras.
+- **FX cache lifecycle** – The `fx_rates` table grows over time without pruning. Consider retention or deduplication strategies if disk usage becomes material.
+- **Performance metrics** – No runtime metrics exist; future work could add diagnostics (e.g., via Home Assistant statistics) for price cycle duration and sync timing.
+- **Large portfolio scalability** – Real-world limits for the on-demand aggregation and DOM patching have not been benchmarked since the refactor; measure before enabling micro-caching.
+
+---
+
+## Glossary
+| Term | Definition |
+|------|------------|
+| Coordinator | Home Assistant `DataUpdateCoordinator` responsible for periodic refreshes. |
+| Entry ID | Unique identifier assigned by Home Assistant to a config entry. |
+| Revaluation | Partial recalculation of portfolio metrics after quote updates. |
+| Drift | Logged warning when Yahoo quote currency differs from stored security currency. |
+| Override cache | Deprecated frontend cache removed after the on-demand aggregation refactor. |
+| FX rate | Exchange rate relative to EUR stored in the `fx_rates` table. |
+| Event patch | Incremental DOM update strategy used by the dashboard. |
+
+_End of architecture documentation._


### PR DESCRIPTION
## Summary
- rewrite `ARCHITECTURE.md` to reflect the current module layout, responsibilities, and external dependencies
- document the data ingestion pipeline, price orchestration, FX helper, WebSocket contracts, and frontend assets now present in the codebase
- capture current testing coverage and open questions around unused dependencies, FX retention, and performance telemetry

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83762cd0c83309fe33c63ff1aefef