### PR TITLE
Fix blocking price service import

### DIFF
--- a/custom_components/pp_reader/__init__.py
+++ b/custom_components/pp_reader/__init__.py
@@ -6,7 +6,6 @@ import logging
 import sys
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime, timedelta
-from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
@@ -24,6 +23,7 @@ from .data import backup_db as backup_db_module
 from .data import coordinator as coordinator_module
 from .data import db_init as db_init_module
 from .data import websocket as websocket_module
+from .prices import price_service as price_service_module
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -59,7 +59,7 @@ CANCEL_EXCEPTIONS: tuple[type[Exception], ...] = (
 
 def _get_price_service_module() -> ModuleType:
     """Return the price service module on demand."""
-    return import_module(".prices.price_service", __name__)
+    return price_service_module
 
 
 def _get_websocket_module() -> ModuleType:


### PR DESCRIPTION
## Summary
- replace the dynamic import of the price service module with a module level import to avoid blocking operations in the event loop

## Testing
- ruff check custom_components/pp_reader/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d8da54018083308eba7e8725803f0f