### PR TITLE
Add helper script for preparing main release PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ Home Assistant can then be started with:
 ./scripts/develop
 ```
 
+## Preparing a release PR for `main`
+
+The `dev` branch contains tooling, fixtures, and development helpers that
+should not reach `main`. Use the helper script to create a sanitized worktree
+that only keeps `custom_components/` together with the required root files
+(`ARCHITECTURE.md`, `CHANGELOG.md`, `hacs.json`, `LICENSE`, `README.md`).
+
+```bash
+./scripts/prepare_main_pr.sh [source_branch] [target_branch] [worktree_dir]
+```
+
+- `source_branch` defaults to `dev`.
+- `target_branch` defaults to `main-release`.
+- `worktree_dir` defaults to `.worktrees/<target_branch>`.
+
+The script checks out the source branch into a separate worktree, prunes every
+tracked file that is not part of the add-on payload, and leaves you with a
+clean branch ready for a pull request against `main`. Review the worktree,
+commit the changes, and push the `target_branch` when you are ready to open the
+PR.
+
 In Codex environments the setup script cannot keep the virtual
 environment active. Run `source .venv/bin/activate` after the container
 starts or use `./scripts/codex_develop` which directly runs the Hass

--- a/scripts/prepare_main_pr.sh
+++ b/scripts/prepare_main_pr.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_BRANCH=${1:-dev}
+TARGET_BRANCH=${2:-main-release}
+WORKTREE_DIR=${3:-".worktrees/${TARGET_BRANCH}"}
+
+ALLOWED_ROOT=(ARCHITECTURE.md CHANGELOG.md hacs.json LICENSE README.md)
+ALLOWED_DIR="custom_components"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+if ! git rev-parse --verify --quiet "${SOURCE_BRANCH}" >/dev/null; then
+  echo "Source branch '${SOURCE_BRANCH}' not found" >&2
+  exit 1
+fi
+
+mkdir -p "${REPO_ROOT}/.worktrees"
+
+echo "Creating release worktree at ${WORKTREE_DIR} from ${SOURCE_BRANCH}" >&2
+if git worktree list | awk '{print $1}' | grep -Fxq "${REPO_ROOT}/${WORKTREE_DIR}"; then
+  git worktree remove "${WORKTREE_DIR}" --force
+fi
+
+git worktree add --force "${WORKTREE_DIR}" "${SOURCE_BRANCH}"
+
+pushd "${WORKTREE_DIR}" >/dev/null
+
+git checkout -B "${TARGET_BRANCH}" >/dev/null
+
+while IFS= read -r path; do
+  case "${path}" in
+    ${ALLOWED_DIR}/*) ;;
+    ${ALLOWED_ROOT[0]}|${ALLOWED_ROOT[1]}|${ALLOWED_ROOT[2]}|${ALLOWED_ROOT[3]}|${ALLOWED_ROOT[4]}) ;;
+    *)
+      git rm -r --cached --quiet "${path}" || true
+      rm -rf "${path}"
+      ;;
+  esac
+done < <(git ls-files)
+
+git clean -fdx >/dev/null
+
+echo "Worktree prepared. Review changes under ${WORKTREE_DIR} and commit when ready." >&2
+
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add `scripts/prepare_main_pr.sh` to generate a sanitized worktree that only keeps release files
- document the release preparation flow in the README so contributors know how to use the script

## Testing
- `./scripts/prepare_main_pr.sh work tmp-test .worktrees/tmp-test`


------
https://chatgpt.com/codex/tasks/task_e_68d90da4c22c8330814ddbfd7b7eebc2