### PR TITLE
Ensure historical price index during initialization

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -1,7 +1,7 @@
 # Daily Close Storage – Implementierungs-Checkliste
 
 1. Datenbankschema absichern
-   a) [ ] Index-Migration für `historical_prices`
+   a) [x] Index-Migration für `historical_prices`
       - Datei: `custom_components/pp_reader/data/db_init.py`
       - Abschnitt/Funktion: `initialize_database_schema`, Hilfsfunktionen für Migrationslogik
       - Ziel: Sicherstellen, dass beim Initialisieren/Upgraden ein `CREATE INDEX IF NOT EXISTS idx_historical_prices_security_date ON historical_prices(security_uuid, date)` ausgeführt wird, damit Abfragen auf Zeitreihen performant laufen.

--- a/custom_components/pp_reader/data/db_init.py
+++ b/custom_components/pp_reader/data/db_init.py
@@ -65,6 +65,23 @@ def _ensure_runtime_price_columns(conn: sqlite3.Connection) -> None:
         )
 
 
+def _ensure_historical_price_index(conn: sqlite3.Connection) -> None:
+    """Create the historical price index if it does not yet exist."""
+
+    try:
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_historical_prices_security_date
+            ON historical_prices(security_uuid, date)
+            """
+        )
+    except sqlite3.Error:
+        _LOGGER.warning(
+            "Konnte Index 'idx_historical_prices_security_date' nicht erzeugen",
+            exc_info=True,
+        )
+
+
 def initialize_database_schema(db_path: Path) -> None:
     """Initialisiert die SQLite Datenbank mit dem definierten Schema."""
     try:
@@ -98,6 +115,7 @@ def initialize_database_schema(db_path: Path) -> None:
 
             # --- NEU: Best-effort Runtime-Migration für Preis-Spalten ---
             _ensure_runtime_price_columns(conn)
+            _ensure_historical_price_index(conn)
 
             conn.commit()
 


### PR DESCRIPTION
## Summary
- add a dedicated helper to create the historical price index during database setup
- invoke the helper during initialization so migrations keep the index in place
- mark the daily close storage checklist item for the index as completed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95019ad888330915da1465ad833af