### PR TITLE
Document retention expectations for historical prices

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -5,7 +5,7 @@
       - Datei: `custom_components/pp_reader/data/db_init.py`
       - Abschnitt/Funktion: `initialize_database_schema`, Hilfsfunktionen für Migrationslogik
       - Ziel: Sicherstellen, dass beim Initialisieren/Upgraden ein `CREATE INDEX IF NOT EXISTS idx_historical_prices_security_date ON historical_prices(security_uuid, date)` ausgeführt wird, damit Abfragen auf Zeitreihen performant laufen.
-   b) [ ] Schema-Kommentar zu Retention ergänzen
+   b) [x] Schema-Kommentar zu Retention ergänzen
       - Datei: `custom_components/pp_reader/data/db_schema.py`
       - Abschnitt/Funktion: Definition von `historical_prices` in `SECURITY_SCHEMA`
       - Ziel: Dokumentieren, dass Close-Werte für aktive Wertpapiere vollständig gehalten werden und welche (ggf. spätere) Aufbewahrungsregeln gelten.

--- a/custom_components/pp_reader/data/db_schema.py
+++ b/custom_components/pp_reader/data/db_schema.py
@@ -57,6 +57,9 @@ SECURITY_SCHEMA = [
         security_uuid TEXT NOT NULL,  -- UUID des Wertpapiers
         date INTEGER NOT NULL,        -- Unix-Timestamp (epoch day)
         close INTEGER NOT NULL,       -- Schlusskurs in 10^-8 Einheiten
+        -- Close-Werte aktiver Wertpapiere werden vollständig gehalten, um
+        -- Zeitreihen ohne Lücken bereitzustellen. Retentionsregeln für
+        -- archivierte Wertpapiere können in zukünftigen Migrationen folgen.
         high INTEGER,                 -- Höchstkurs in 10^-8 Einheiten
         low INTEGER,                  -- Tiefstkurs in 10^-8 Einheiten
         volume INTEGER,               -- Handelsvolumen


### PR DESCRIPTION
## Summary
- document the retention expectations for the historical_prices table so daily close series handling is clear
- mark the related checklist item in `.docs/TODO_daily_close_storage.md` as complete

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d95dd48eb48330b990425a03151b96