### PR TITLE
Guard historical price inserts against retired securities

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -11,7 +11,7 @@
       - Ziel: Dokumentieren, dass Close-Werte für aktive Wertpapiere vollständig gehalten werden und welche (ggf. spätere) Aufbewahrungsregeln gelten.
 
 2. Importer für Tages-Schlusskurse härten
-   a) [ ] Aktive Wertpapiere vor Persistenz filtern
+   a) [x] Aktive Wertpapiere vor Persistenz filtern
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: `_sync_securities`
       - Ziel: Nur Securities mit `retired = 0` für neue Einträge in `historical_prices` berücksichtigen und trotzdem bestehende Historie für bereits archivierte Papiere bewahren.

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -553,30 +553,31 @@ class _SyncRunner:
                 self.updated_data["securities"].append(security.uuid)
 
             if security.prices:
-                for price in security.prices:
-                    descriptor = getattr(price, "DESCRIPTOR", None)
-                    fields = descriptor.fields_by_name if descriptor else {}
-                    high = getattr(price, "high", None) if "high" in fields else None
-                    low = getattr(price, "low", None) if "low" in fields else None
-                    volume = (
-                        getattr(price, "volume", None) if "volume" in fields else None
-                    )
+                if not retired:
+                    for price in security.prices:
+                        descriptor = getattr(price, "DESCRIPTOR", None)
+                        fields = descriptor.fields_by_name if descriptor else {}
+                        high = getattr(price, "high", None) if "high" in fields else None
+                        low = getattr(price, "low", None) if "low" in fields else None
+                        volume = (
+                            getattr(price, "volume", None) if "volume" in fields else None
+                        )
 
-                    self.cursor.execute(
-                        """
-                        INSERT OR REPLACE INTO historical_prices (
-                            security_uuid, date, close, high, low, volume
-                        ) VALUES (?,?,?,?,?,?)
-                        """,
-                        (
-                            security.uuid,
-                            price.date,
-                            price.close,
-                            high,
-                            low,
-                            volume,
-                        ),
-                    )
+                        self.cursor.execute(
+                            """
+                            INSERT OR REPLACE INTO historical_prices (
+                                security_uuid, date, close, high, low, volume
+                            ) VALUES (?,?,?,?,?,?)
+                            """,
+                            (
+                                security.uuid,
+                                price.date,
+                                price.close,
+                                high,
+                                low,
+                                volume,
+                            ),
+                        )
 
                 latest_price = max(security.prices, key=lambda price: price.date)
                 _require_timestamp_support()


### PR DESCRIPTION
## Summary
- skip writing historical price entries for retired securities during sync
- mark the daily close storage checklist item as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d96f1e3c5c8330b6f1d0be4616638f