### PR TITLE
Batch insert historical prices during sync

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -19,7 +19,7 @@
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: `_sync_securities`
       - Ziel: Preise nach Datum sortieren, Duplikate pro `(security_uuid, date)` entfernen und fehlende Pflichtfelder (`close`) validieren, bevor geschrieben wird.
-   c) [ ] Batch-Insert via `executemany`
+   c) [x] Batch-Insert via `executemany`
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: `_sync_securities`
       - Ziel: Gesäuberte Preislisten gesammelt per `executemany` mit `INSERT OR REPLACE` einspielen, damit große Dateien performant verarbeitet werden.

--- a/.docs/TODO_updateGoals.md
+++ b/.docs/TODO_updateGoals.md
@@ -1,0 +1,3 @@
+# Daily Close Storage – Update Goals
+
+- ☑ 2c) Batch-Insert via `executemany` in `custom_components/pp_reader/data/sync_from_pclient.py`

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -598,22 +598,28 @@ class _SyncRunner:
                             volume,
                         )
 
-                    for date_value in sorted(dedup_prices):
-                        close_value, high, low, volume = dedup_prices[date_value]
-                        self.cursor.execute(
+                    rows_to_persist = [
+                        (
+                            security.uuid,
+                            date_value,
+                            close_value,
+                            high,
+                            low,
+                            volume,
+                        )
+                        for date_value, (close_value, high, low, volume) in sorted(
+                            dedup_prices.items()
+                        )
+                    ]
+
+                    if rows_to_persist:
+                        self.cursor.executemany(
                             """
                             INSERT OR REPLACE INTO historical_prices (
                                 security_uuid, date, close, high, low, volume
                             ) VALUES (?,?,?,?,?,?)
                             """,
-                            (
-                                security.uuid,
-                                date_value,
-                                close_value,
-                                high,
-                                low,
-                                volume,
-                            ),
+                            rows_to_persist,
                         )
 
                 latest_price = max(security.prices, key=lambda price: price.date)


### PR DESCRIPTION
## Summary
- replace the per-row historical price inserts in the Portfolio Performance sync with a batched `executemany` call
- update the daily close storage checklist to reflect the completed batch insert step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d986bec7588330b7457a5a8b3d97d4