### PR TITLE
Document development environment evaluation

### DIFF
--- a/.docs/dev_environment_review.md
+++ b/.docs/dev_environment_review.md
@@ -1,0 +1,18 @@
+# Development Environment Evaluation
+
+## Environment settings overview
+- The devcontainer image is pinned to `mcr.microsoft.com/devcontainers/python:3.13`, installs Home Assistant system build dependencies via the `apt-packages` feature, and runs `scripts/setup` followed by `python3 -m pip install --requirement requirements-dev.txt` after creation.【F:.devcontainer.json†L1-L41】
+- The Codex setup script invoked by the environment also runs `scripts/setup_container`, which installs apt packages, creates/activates `.venv`, upgrades `pip`, and installs only the runtime requirements.【F:scripts/setup_container†L1-L28】
+
+## Gaps impacting development & testing
+- `scripts/setup_container` does not install the development requirements, so pytest and helper tooling are only available because the devcontainer post-create hook runs an additional installation; Codex environments that rely solely on the setup script will miss testing dependencies. Add `pip install --requirement requirements-dev.txt` to the script to make testing available everywhere.【F:scripts/setup_container†L1-L28】【F:requirements-dev.txt†L1-L4】
+- The runtime requirements pin `homeassistant==2025.2.4` while `pytest-homeassistant-custom-component` pulls in `homeassistant==2025.10.0b4`. This version skew can introduce subtle import/runtime issues; align the versions or constrain `pytest-homeassistant-custom-component` to match the integration's target release.【F:requirements.txt†L1-L4】【F:requirements-dev.txt†L1-L4】
+- Pytest currently fails because our local `tests` package masks the helper package from `pytest-homeassistant-custom-component`, making `tests.common` unavailable. Provide a shim module (e.g. `tests/common.py` that re-exports the upstream helpers) or adjust imports to reference `pytest_homeassistant_custom_component.common` directly so the suite can run in a clean environment.【F:tests/__init__.py†L1-L1】【9b98ba†L6-L43】
+
+## Start log review
+- No startup log was generated under `/root`, `/workspace`, or `/tmp`, so the Codex setup output appears to be discarded. If logging is desired, enable the "Log output" option or redirect the setup script output into a file for later inspection.【fa6082†L1-L1】
+
+## Recommended configuration changes
+1. Extend `scripts/setup_container` to install `requirements-dev.txt` and optionally run `pip install --upgrade pip` only once to avoid redundant upgrades (the runtime requirement on `pip>=21.3.1` already ensures a minimum version).【F:scripts/setup_container†L1-L28】【F:requirements.txt†L1-L4】
+2. Ensure the Codex setup command list matches the devcontainer bootstrap (remove duplicate `./scripts/setup_container` entries, drop the nonexistent `./scripts/install_coverage` invocation, and source `.venv/bin/activate` only when executing follow-up commands).【F:scripts/setup_container†L1-L28】
+3. Add a helper module so `tests.common` resolves, or switch imports to the canonical helper package. This change lives in the repo, but without it automated tests in Codex will continue to fail.【9b98ba†L6-L43】


### PR DESCRIPTION
## Summary
- document the current Codex/devcontainer setup and the gaps that affect development and testing
- record recommendations for aligning the setup script, dependency versions, and pytest helper imports

## Testing
- ❌ `pytest` *(fails: ModuleNotFoundError: No module named 'tests.common')*

------
https://chatgpt.com/codex/tasks/task_e_68d986632b60833087fa51d36493d9f2