### PR TITLE
Add helper to materialize security close price series

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -37,7 +37,7 @@
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: Neuer Funktionsblock unterhalb bestehender Getter
       - Ziel: Reihenweise `(date, close)` für eine Security optional gefiltert nach `start_date`/`end_date` in aufsteigender Reihenfolge liefern; Eingabewerte validieren.
-   b) [ ] Komfortfunktion `get_security_close_prices`
+   b) [x] Komfortfunktion `get_security_close_prices`
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: Direkt neben dem Generator
       - Ziel: Vollständige Liste der Close-Paare auf Basis des Generators materialisieren, damit Consumer ohne Generator-Handling arbeiten können.

--- a/custom_components/pp_reader/data/db_access.py
+++ b/custom_components/pp_reader/data/db_access.py
@@ -256,6 +256,24 @@ def iter_security_close_prices(
         conn.close()
 
 
+def get_security_close_prices(
+    db_path: Path,
+    security_uuid: str,
+    start_date: int | None = None,
+    end_date: int | None = None,
+) -> list[tuple[int, int]]:
+    """Gibt tägliche Schlusskurse eines Wertpapiers als Liste zurück."""
+
+    return list(
+        iter_security_close_prices(
+            db_path=db_path,
+            security_uuid=security_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    )
+
+
 def get_accounts(db_path: Path) -> list[Account]:
     """Lädt alle Konten aus der DB."""
     conn = sqlite3.connect(str(db_path))


### PR DESCRIPTION
## Summary
- add `get_security_close_prices` helper that materialises security close tuples for easy consumption
- update the daily close storage checklist to reflect the completed helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d995cd0b08833093cc9804f7c70c89