### PR TITLE
Setup feature flag defaults in entry store

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -55,7 +55,7 @@
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Abschnitt/Funktion: Neuer Handler `ws_get_security_history`
       - Ziel: Bei aktivem Feature-Flag Close-Serien über `iter_security_close_prices` liefern; andernfalls Fehler `feature_not_enabled` zurückgeben.
-   c) [ ] Feature-Flag im Entry-Setup dokumentieren
+   c) [x] Feature-Flag im Entry-Setup dokumentieren
       - Datei: `custom_components/pp_reader/__init__.py`
       - Abschnitt/Funktion: `async_setup_entry`
       - Ziel: Optionen/Defaultwerte für `pp_reader_history` setzen und interne Ablage (`hass.data[DOMAIN][entry_id]["feature_flags"]`) vorbereiten.


### PR DESCRIPTION
## Summary
- normalize feature flag overrides from config entry options
- persist pp_reader_history defaults in the hass.data entry store during setup and reload
- mark the corresponding daily close storage checklist item as complete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d99e8022c483309cf8fa791983d05e