### PR TITLE
Document historical close storage enhancements

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -87,7 +87,7 @@
       - Datei: `ARCHITECTURE.md`
       - Abschnitt/Funktion: Kapitel zu Persistenz/Storage
       - Ziel: Datenfluss des Daily-Close-Speichers, Interaktion mit Importer & WebSocket beschreiben.
-   b) [ ] Änderungsprotokoll aktualisieren
+   b) [x] Änderungsprotokoll aktualisieren
       - Datei: `CHANGELOG.md`
       - Abschnitt/Funktion: Neuer Eintrag unter "Unreleased"
       - Ziel: Einführung der historischen Close-Speicherung und des optionalen History-WebSockets dokumentieren.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All noteworthy changes to this project are recorded in this file.
 Format follows: Keep a Changelog
 Versioning: SemVer (minor bump for new functionality without breaking changes).
 
+## [Unreleased]
+### Added
+- Persist daily Close prices for active securities during Portfolio Performance imports and provide helpers to query their time series for future dashboards.【F:custom_components/pp_reader/data/sync_from_pclient.py†L559-L676】【F:custom_components/pp_reader/data/db_access.py†L204-L289】
+- Introduced a feature-flagged WebSocket command (`pp_reader/get_security_history`) that streams Close data when explicitly enabled, paving the way for historical price visualisations.【F:custom_components/pp_reader/data/websocket.py†L396-L496】【F:custom_components/pp_reader/feature_flags.py†L1-L101】
+
 ## [0.11.0] - 2025-09-27
 ### Added
 - New database helper `fetch_live_portfolios` aggregates current portfolio values and position counts on demand as the single source of truth for WebSocket responses and dashboard load paths.【F:custom_components/pp_reader/data/db_access.py†L428-L484】


### PR DESCRIPTION
## Summary
- add an "Unreleased" changelog section describing the new historical close storage helpers and WebSocket endpoint
- mark the daily close storage checklist item for the changelog update as complete

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68da392073488330ac3d80be4af46150