### PR TITLE
Add pytest scaffolding for integration tests

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -96,6 +96,9 @@
    a) [ ] Unit- und Integrations-Tests ausführen
       - Datei/Command: `pytest`
       - Ziel: Alle neuen Testfälle bestehen.
+      - Notiz 2025-03-18: Testlauf gestartet (`pytest`), schlägt aktuell u. a. wegen fehlender `securities.type`-Spalte und fehlender
+        `async_create_background_task`-Implementierung in Stub-WebSocket-Helpern fehl; weiterer Abgleich mit bestehender
+        Test-Infrastruktur erforderlich.
    b) [ ] Manuelle Importprobe
       - Datei/Command: Portfolio-Export in Testinstanz laden
       - Ziel: Prüfen, dass `historical_prices` nach Import gefüllt ist und Re-Import ohne Duplikate bleibt.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+filterwarnings =
+    ignore::pytest.PytestUnknownMarkWarning

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,75 @@
+"""Lightweight test helpers mirroring Home Assistant fixtures."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from homeassistant.config_entries import (
+    SOURCE_USER,
+    ConfigEntries,
+    ConfigEntry,
+    ConfigEntryState,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.util import ulid as ulid_util
+
+
+class MockConfigEntry(ConfigEntry):
+    """Minimal ConfigEntry stub for integration tests."""
+
+    def __init__(
+        self,
+        *,
+        data: Mapping[str, Any] | None = None,
+        disabled_by: str | None = None,
+        discovery_keys: Mapping[str, tuple[Any, ...]] | None = None,
+        domain: str = "test",
+        entry_id: str | None = None,
+        minor_version: int = 1,
+        options: Mapping[str, Any] | None = None,
+        pref_disable_new_entities: bool | None = None,
+        pref_disable_polling: bool | None = None,
+        reason: str | None = None,
+        source: str = SOURCE_USER,
+        state: ConfigEntryState | None = None,
+        title: str = "Mock Title",
+        unique_id: str | None = None,
+        version: int = 1,
+    ) -> None:
+        """Initialise a mock config entry with safe defaults."""
+
+        normalized_keys = {
+            key: tuple(value)
+            for key, value in (discovery_keys or {}).items()
+        }
+
+        super().__init__(
+            data=data or {},
+            disabled_by=disabled_by,
+            discovery_keys=MappingProxyType(normalized_keys),
+            domain=domain,
+            entry_id=entry_id or ulid_util.ulid_now(),
+            minor_version=minor_version,
+            options=MappingProxyType(dict(options or {})),
+            pref_disable_new_entities=pref_disable_new_entities,
+            pref_disable_polling=pref_disable_polling,
+            source=source,
+            state=state or ConfigEntryState.NOT_LOADED,
+            title=title,
+            unique_id=unique_id,
+            version=version,
+        )
+
+        if reason is not None:
+            object.__setattr__(self, "reason", reason)
+
+    def add_to_hass(self, hass: HomeAssistant) -> None:
+        """Register the entry on Home Assistant's config manager."""
+
+        hass.config_entries._entries[self.entry_id] = self
+
+    def add_to_manager(self, manager: ConfigEntries) -> None:
+        """Register the entry on an explicit config manager."""
+
+        manager._entries[self.entry_id] = self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Pytest fixtures to bootstrap Home Assistant core for integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntries
+from homeassistant.core import HomeAssistant
+
+pytest_plugins = ("pytest_asyncio",)
+
+
+@pytest.fixture
+def event_loop() -> AsyncGenerator[asyncio.AbstractEventLoop, None]:
+    """Create a fresh event loop per test session."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+async def hass(event_loop: asyncio.AbstractEventLoop, tmp_path) -> AsyncGenerator[HomeAssistant, None]:
+    """Provide a running Home Assistant instance backed by a temp config dir."""
+
+    asyncio.set_event_loop(event_loop)
+    hass = HomeAssistant(str(tmp_path))
+    hass.config_entries = ConfigEntries(hass, {})
+    await hass.config_entries.async_initialize()
+
+    try:
+        yield hass
+    finally:
+        await hass.async_stop(force=True)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Summary
- add pytest configuration to enable asyncio mode and silence deprecated async markers
- provide local `MockConfigEntry` helper and Home Assistant bootstrap fixtures for tests
- document outstanding pytest failures in the daily close storage checklist

## Testing
- `pytest` *(fails: missing `securities.type` column, StubHass lacks async task helper)*

------
https://chatgpt.com/codex/tasks/task_e_68da3b022da483308516c6c0bcd00b79