### PR TITLE
Add background task scheduling helpers to websocket test stubs

### DIFF
--- a/tests/test_revaluation_live_aggregation.py
+++ b/tests/test_revaluation_live_aggregation.py
@@ -17,6 +17,12 @@ class StubHass:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, func, *args)
 
+    def async_create_background_task(
+        self, coro, _task_name=None, *, eager_start: bool = False
+    ):
+        loop = asyncio.get_running_loop()
+        return loop.create_task(coro)
+
 
 @pytest.mark.asyncio
 async def test_revaluation_uses_live_portfolio_values(tmp_path: Path) -> None:

--- a/tests/test_ws_accounts_fx.py
+++ b/tests/test_ws_accounts_fx.py
@@ -99,6 +99,13 @@ class StubHass:
         """Execute blocking helpers synchronously for tests."""
         return func(*args)
 
+    def async_create_background_task(
+        self, coro, _task_name=None, *, eager_start: bool = False
+    ):
+        """Schedule the coroutine on the running event loop."""
+        loop = asyncio.get_running_loop()
+        return loop.create_task(coro)
+
 
 def _make_account(currency: str, balance: int = 10000) -> object:
     class Account:

--- a/tests/test_ws_last_file_update.py
+++ b/tests/test_ws_last_file_update.py
@@ -70,7 +70,9 @@ class StubHass:
     async def async_add_executor_job(self, func, *args):
         return func(*args)
 
-    def async_create_background_task(self, coro, _task_name=None, *, eager_start=False):
+    def async_create_background_task(
+        self, coro, _task_name=None, *, eager_start: bool = False
+    ):
         loop = asyncio.get_running_loop()
         return loop.create_task(coro)
 

--- a/tests/test_ws_portfolios_live.py
+++ b/tests/test_ws_portfolios_live.py
@@ -63,6 +63,12 @@ class StubHass:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, func, *args)
 
+    def async_create_background_task(
+        self, coro, _task_name=None, *, eager_start: bool = False
+    ):
+        loop = asyncio.get_running_loop()
+        return loop.create_task(coro)
+
 
 @pytest.mark.asyncio
 async def test_ws_get_portfolio_data_returns_live_values(initialized_db: Path) -> None:


### PR DESCRIPTION
## Summary
- add async_create_background_task implementations to websocket StubHass helpers and the minimal HomeAssistant stub used in tests
- update the security history harness to drive the decorated websocket handler on a managed event loop

## Testing
- pytest tests/test_ws_accounts_fx.py tests/test_ws_portfolios_live.py tests/test_ws_last_file_update.py tests/test_ws_security_history.py

------
https://chatgpt.com/codex/tasks/task_e_68da45546ac483308976c3dad7d0ce10