### PR TITLE
Add Home Assistant stubs for pytest setup

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -99,6 +99,8 @@
       - Notiz 2025-03-20: `pytest` läuft jetzt bis zur Integrationseinrichtung durch, scheitert aber an fehlendem Home Assistant
         Loader-Setup (`KeyError: 'integrations'` / `Integration not found`) sowie fehlenden Listener-Stubs (z. B.
         `async_track_time_interval`). Zusätzliche Test-Fixture-Ergänzungen für Loader-Cache und Event-Helfer erforderlich.
+      - Fortschritt 2025-03-21: Loader-/HTTP-Stubs & Coordinator-Noop für Tests ergänzt; Suite bricht nun erst an
+        funktionalen Assertions (Logger-Scope, Zero-Quotes-WARN, WS-Loop) ab.
    b) [ ] Manuelle Importprobe
       - Datei/Command: Portfolio-Export in Testinstanz laden
       - Ziel: Prüfen, dass `historical_prices` nach Import gefüllt ist und Re-Import ohne Duplikate bleibt.

--- a/custom_components/pp_reader/data/db_schema.py
+++ b/custom_components/pp_reader/data/db_schema.py
@@ -43,7 +43,6 @@ SECURITY_SCHEMA = [
         feed TEXT,
         type TEXT,
         currency_code TEXT,
-        type TEXT,
         retired INTEGER,
         updated_at TEXT,
         last_price INTEGER,           -- Letzter Preis in 10^-8 Einheiten

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from homeassistant.loader import (
     DATA_COMPONENTS,
     DATA_CUSTOM_COMPONENTS,
     DATA_INTEGRATIONS,
+    DATA_MISSING_PLATFORMS,
     DATA_PRELOAD_PLATFORMS,
     Integration,
 )
@@ -41,24 +42,54 @@ async def hass(event_loop: asyncio.AbstractEventLoop, tmp_path) -> AsyncGenerato
     hass = HomeAssistant(str(tmp_path))
     hass.config_entries = ConfigEntries(hass, {})
     await hass.config_entries.async_initialize()
+
+    class _HttpStub:
+        async def async_register_static_paths(self, _paths):
+            return None
+
+        async def async_register_view(self, _view):  # pragma: no cover - compatibility
+            return None
+
+    hass.http = _HttpStub()
     hass.data.setdefault(DATA_INTEGRATIONS, {})
     hass.data.setdefault(DATA_CUSTOM_COMPONENTS, {})
-    hass.data.setdefault(DATA_COMPONENTS, set())
+    hass.data.setdefault(DATA_COMPONENTS, {})
+    hass.data.setdefault(DATA_MISSING_PLATFORMS, {})
     hass.data.setdefault(DATA_PRELOAD_PLATFORMS, set())
 
     # Register the pp_reader integration so loader lookups succeed during tests.
     try:
         import custom_components  # noqa: PLC0415 - imported for side effect
+    except ImportError:  # pragma: no cover - repository layout unexpected
+        custom_components = None
 
+    if custom_components is not None:
         integration = Integration.resolve_from_root(hass, custom_components, "pp_reader")
-        if integration is not None:
-            hass.data[DATA_CUSTOM_COMPONENTS][integration.domain] = integration
-            hass.data[DATA_INTEGRATIONS][integration.domain] = integration
-    except Exception:  # pragma: no cover - defensive guard for unusual environments
-        pass
+        if integration is None:  # pragma: no cover - would indicate invalid manifest
+            raise RuntimeError("Failed to resolve pp_reader integration for tests")
+
+        hass.data[DATA_CUSTOM_COMPONENTS][integration.domain] = integration
+        hass.data[DATA_INTEGRATIONS][integration.domain] = integration
+
+        # Ensure the package exposes its module under the __init__ attribute so tests
+        # using monkeypatch paths like ``custom_components.pp_reader.__init__`` work.
+        import custom_components.pp_reader as pp_reader_module
+
+        setattr(custom_components.pp_reader, "__init__", pp_reader_module)
+
+    # Avoid loading real portfolio data during tests; coordinator sync is patched to no-op.
+    from custom_components.pp_reader.data.coordinator import PPReaderCoordinator
+
+    original_sync_portfolio_file = PPReaderCoordinator._sync_portfolio_file
+
+    async def _noop_sync_portfolio_file(self, _last_update):
+        return None
+
+    PPReaderCoordinator._sync_portfolio_file = _noop_sync_portfolio_file
 
     try:
         yield hass
     finally:
+        PPReaderCoordinator._sync_portfolio_file = original_sync_portfolio_file
         await hass.async_stop(force=True)
         await hass.async_block_till_done()

--- a/tests/test_currency_drift_once.py
+++ b/tests/test_currency_drift_once.py
@@ -44,7 +44,7 @@ async def test_currency_drift_warn_once(hass, tmp_path, monkeypatch, caplog):
         conn.commit()
 
     # --- Provider Patch: immer gleicher Preis + mismatched currency (EUR) ---
-    async def fake_fetch(symbols):
+    async def fake_fetch(self, symbols):
         assert symbols == ["AAA"]
         return {
             "AAA": Quote(

--- a/tests/test_error_counter_reset.py
+++ b/tests/test_error_counter_reset.py
@@ -60,7 +60,7 @@ async def test_error_counter_reset_after_success(hass, tmp_path, monkeypatch, ca
     # --- Provider Fetch Patch (2x leer, dann Quote) ---
     call_state = {"cycle": 0}
 
-    async def fake_fetch(_symbols):
+    async def fake_fetch(self, _symbols):
         # Jede _run_price_cycle ruft fetch pro Batch einmal auf (eine Symbolgruppe)
         if call_state["cycle"] < 2:
             call_state["cycle"] += 1

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -158,7 +158,7 @@ async def test_change_triggers_events(monkeypatch, tmp_path):
             "portfolio_positions": None,
         }
 
-    async def fake_fetch(symbols):
+    async def fake_fetch(self, symbols):
         return {"AAPL": _make_quote("AAPL", 1.05, "USD")}
 
     monkeypatch.setattr(price_service, "_push_update", fake_push)
@@ -189,7 +189,7 @@ async def test_no_change_no_events(monkeypatch, tmp_path):
     async def fake_reval(hass_, conn, uuids):
         return {"portfolio_values": {"pf1": {}}, "portfolio_positions": None}
 
-    async def fake_fetch(symbols):
+    async def fake_fetch(self, symbols):
         return {"AAPL": _make_quote("AAPL", 1.05, "USD")}
 
     monkeypatch.setattr(price_service, "_push_update", fake_push)
@@ -208,7 +208,7 @@ async def test_fetch_uses_configured_timeout(monkeypatch, tmp_path):
     db_path = _create_db_with_security(tmp_path, "sec1", "AAPL", "USD", None)
     _init_store(hass, entry_id, db_path, {"AAPL": ["sec1"]})
 
-    async def fake_fetch(symbols):
+    async def fake_fetch(self, symbols):
         return {"AAPL": _make_quote("AAPL", 1.0, "USD")}
 
     async def fake_wait_for(awaitable, timeout, *, loop=None):
@@ -252,7 +252,7 @@ async def test_currency_drift_warn_once(monkeypatch, tmp_path, caplog):
     async def fake_reval(hass_, conn, uuids):
         return {"portfolio_values": {}, "portfolio_positions": None}
 
-    async def fake_fetch(symbols):
+    async def fake_fetch(self, symbols):
         # Quote currency abweichend (EUR vs USD in DB)
         return {"AAPL": _make_quote("AAPL", 1.11, "EUR")}
 
@@ -292,10 +292,10 @@ async def test_error_counter_increment_and_reset(monkeypatch, tmp_path, caplog):
         return {"portfolio_values": {}, "portfolio_positions": None}
 
     # Zero-Quotes (leer)
-    async def empty_fetch(symbols):
+    async def empty_fetch(self, symbols):
         return {}
 
-    async def success_fetch(symbols):
+    async def success_fetch(self, symbols):
         return {"AAPL": _make_quote("AAPL", 2.0, "USD")}
 
     monkeypatch.setattr(price_service, "revalue_after_price_updates", fake_reval)
@@ -343,7 +343,7 @@ async def test_no_drift_none_currency(monkeypatch, tmp_path, caplog):
         return {"portfolio_values": {}, "portfolio_positions": None}
 
     # Quote ohne currency (None) -> sollte von Drift-Prüfung ignoriert werden
-    async def fetch_no_currency(symbols):
+    async def fetch_no_currency(self, symbols):
         return {"AAPL": _make_quote("AAPL", 3.0, None)}
 
     monkeypatch.setattr(price_service, "revalue_after_price_updates", fake_reval)

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -49,7 +49,7 @@ async def test_watchdog_warn(monkeypatch, hass, tmp_path, caplog):
     store["price_symbol_map"] = {"AAPL": ["sec-1"]}
 
     # Fake Provider Fetch (verhindert echten yahooquery Import / Netzwerk)
-    async def fake_fetch(_symbols):
+    async def fake_fetch(self, _symbols):
         return {
             "AAPL": Quote(
                 symbol="AAPL",

--- a/tests/test_zero_quotes_warn.py
+++ b/tests/test_zero_quotes_warn.py
@@ -43,7 +43,7 @@ async def test_zero_quotes_warn_deduplicated(hass, tmp_path, monkeypatch, caplog
         conn.commit()
 
     # --- Patch Provider: immer leeres Dict (0 Quotes) ---
-    async def fake_fetch(_symbols):
+    async def fake_fetch(self, _symbols):
         return {}
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- remove the duplicated `type` column from the security schema definition so the schema migrates cleanly during tests
- extend the pytest Home Assistant fixture to register the custom integration, provide HTTP/coordinator stubs, and expose the package alias used by monkeypatch-based tests
- update price service related tests to patch bound provider methods correctly and note progress on the QA checklist

## Testing
- `pytest` *(fails: logger scope expectations and zero-quotes WARN assertion still outstanding)*

------
https://chatgpt.com/codex/tasks/task_e_68da65d618808330bc2fe9aed41a174a