### PR TITLE
Add warnings for missing historical close data

### DIFF
--- a/.docs/TODO_daily_close_storage.md
+++ b/.docs/TODO_daily_close_storage.md
@@ -109,7 +109,7 @@
       - Ziel: Sicherstellen, dass `pp_reader/get_security_history` bei aktivem Flag Daten liefert.
 
 8. Weitere Nacharbeiten
-   a) [ ] Warnungen bei fehlenden Tagesdaten instrumentieren
+   a) [x] Warnungen bei fehlenden Tagesdaten instrumentieren
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: `_sync_securities`
       - Ziel: Logging/Telemetry aufbauen, das Lücken in Zeitreihen erkennt und meldet.


### PR DESCRIPTION
## Summary
- add instrumentation for detecting gaps in historical close prices and include the counts in import statistics
- log concise warnings for missing days per security while batching persistence
- cover the new behaviour with a sync_from_pclient test and tick the checklist entry

## Testing
- `pytest tests/test_sync_from_pclient.py::test_sync_securities_warns_about_missing_daily_prices -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68da8d4cac208330ba8420d145200c3c