### PR TITLE
Add security snapshot aggregation helper

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -1,7 +1,7 @@
 # Security Detail Tab Implementation Checklist
 
 1. Backend: Security snapshot data endpoint
-   a) [ ] Implement `get_security_snapshot(db_path: Path, security_uuid: str)` to aggregate holdings and normalize EUR values
+   a) [x] Implement `get_security_snapshot(db_path: Path, security_uuid: str)` to aggregate holdings and normalize EUR values
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: Neuer Helper unterhalb bestehender snapshot/portfolio Utilities
       - Ziel: Liefert `{name, currency_code, total_holdings, last_price_eur, market_value_eur}` aus `portfolio_securities` + `securities` inkl. FX-Konvertierung


### PR DESCRIPTION
## Summary
- add a database helper that aggregates security holdings and converts last price values to EUR
- ensure FX rates are available when converting non-EUR securities
- mark the security detail tab checklist item for the snapshot helper as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf68d79cc8330be649a688d78948c