### PR TITLE
Reuse portfolio FX normalization for security snapshot

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -5,7 +5,7 @@
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: Neuer Helper unterhalb bestehender snapshot/portfolio Utilities
       - Ziel: Liefert `{name, currency_code, total_holdings, last_price_eur, market_value_eur}` aus `portfolio_securities` + `securities` inkl. FX-Konvertierung
-   b) [ ] Reuse vorhandene FX/Nominal-Konvertierung aus Portfolio-Logik für `get_security_snapshot`
+   b) [x] Reuse vorhandene FX/Nominal-Konvertierung aus Portfolio-Logik für `get_security_snapshot`
       - Datei: `custom_components/pp_reader/logic/portfolio.py`
       - Abschnitt/Funktion: Bestehende EUR-Normalisierungsfunktionen referenzieren/auslagern
       - Ziel: Sicherstellen, dass Snapshot-Werte mit Portfolio-Bewertungen identisch berechnet werden


### PR DESCRIPTION
## Summary
- add a synchronous helper in the portfolio logic to convert raw security prices into EUR using stored FX rates
- update the security snapshot query to reuse the shared conversion helper for consistent pricing
- mark the related security detail tab checklist item as completed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dafb4f9c408330b006b259f67b2ac6