### PR TITLE
Remove history websocket feature flag gate

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -19,7 +19,7 @@
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Abschnitt/Funktion: Neuer `@websocket_api.websocket_command` für Typ `pp_reader/get_security_snapshot`
       - Ziel: Validiert Payload, ruft `get_security_snapshot` via Executor und sendet Snapshot-Resultat
-   b) [ ] Entferne Feature-Flag-Gating für `pp_reader/get_security_history`
+   b) [x] Entferne Feature-Flag-Gating für `pp_reader/get_security_history`
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Abschnitt/Funktion: Handler `ws_get_security_history`
       - Ziel: Historien-Endpunkt ist standardmäßig aktiv und liefert Fehler nur bei fehlenden Daten

--- a/custom_components/pp_reader/data/websocket.py
+++ b/custom_components/pp_reader/data/websocket.py
@@ -27,8 +27,6 @@ from .db_access import (
     get_security_snapshot,
     iter_security_close_prices,
 )
-from ..feature_flags import is_enabled as is_feature_enabled
-
 
 def _collect_active_fx_currencies(accounts: Iterable[Any]) -> set[str]:
     """Return all non-EUR currencies from active accounts."""
@@ -488,21 +486,13 @@ async def ws_get_security_history(
     connection: ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Return historical close prices for a security when the feature flag is enabled."""
+    """Return historical close prices for a security."""
 
     msg_id = msg.get("id")
     entry_id = msg.get("entry_id")
 
     if not entry_id:
         connection.send_error(msg_id, "invalid_format", "entry_id erforderlich")
-        return
-
-    if not is_feature_enabled("pp_reader_history", hass, entry_id=entry_id):
-        connection.send_error(
-            msg_id,
-            "feature_not_enabled",
-            "Historische Kursdaten sind derzeit deaktiviert.",
-        )
         return
 
     domain_entries = hass.data.get(DOMAIN)


### PR DESCRIPTION
## Summary
- allow the security history websocket command to be available without the pp_reader_history feature flag
- update the security detail implementation checklist to reflect the completed backend change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db7e9dcb888330b03bb354cedc76a1