### PR TITLE
Remove legacy history feature flag default

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -23,7 +23,7 @@
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Abschnitt/Funktion: Handler `ws_get_security_history`
       - Ziel: Historien-Endpunkt ist standardmäßig aktiv und liefert Fehler nur bei fehlenden Daten
-   c) [ ] Passe Feature-Flag-Defaults an, so dass `pp_reader_history` nicht mehr existiert
+   c) [x] Passe Feature-Flag-Defaults an, so dass `pp_reader_history` nicht mehr existiert
       - Dateien: `custom_components/pp_reader/__init__.py`, `custom_components/pp_reader/feature_flags.py`
       - Abschnitt/Funktion: Feature-Flag-Initialisierung und Defaults
       - Ziel: Entfernt Flag-Definition und Initialisierung; History gilt als Kernfunktion

--- a/custom_components/pp_reader/__init__.py
+++ b/custom_components/pp_reader/__init__.py
@@ -100,9 +100,8 @@ def _extract_feature_flag_options(options: Mapping[str, Any]) -> dict[str, bool]
 
 
 def _store_feature_flags(store: dict[str, Any], overrides: Mapping[str, bool]) -> dict[str, bool]:
-    """Persist feature flag values in the entry store with defaults applied."""
+    """Persist feature flag values in the entry store."""
     flags = dict(overrides)
-    flags.setdefault("pp_reader_history", False)
     store["feature_flags"] = flags
     return flags
 

--- a/custom_components/pp_reader/feature_flags.py
+++ b/custom_components/pp_reader/feature_flags.py
@@ -9,9 +9,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-_DEFAULT_FLAGS: dict[str, bool] = {
-    "pp_reader_history": False,
-}
+_DEFAULT_FLAGS: dict[str, bool] = {}
 
 
 def _normalize_name(name: str) -> str:


### PR DESCRIPTION
## Summary
- drop the deprecated `pp_reader_history` default from the feature flag helper
- stop seeding the removed flag in the config entry feature flag store
- mark the corresponding checklist task as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db80794dd08330934a63a23b75ec0c