### PR TITLE
docs: remove pp_reader_history flag references

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -27,7 +27,7 @@
       - Dateien: `custom_components/pp_reader/__init__.py`, `custom_components/pp_reader/feature_flags.py`
       - Abschnitt/Funktion: Feature-Flag-Initialisierung und Defaults
       - Ziel: Entfernt Flag-Definition und Initialisierung; History gilt als Kernfunktion
-   d) [ ] Bereinige Doku- und Beispielreferenzen auf `pp_reader_history`
+   d) [x] Bereinige Doku- und Beispielreferenzen auf `pp_reader_history`
       - Dateien: `ARCHITECTURE.md`, `README-dev.md`
       - Abschnitt/Funktion: Feature-Flag-Beschreibungen, Tabellen
       - Ziel: Dokumentation aktualisieren, dass History dauerhaft aktiv ist

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -294,11 +294,11 @@ The FX helper logs and returns partial results on network or database failures t
 | `pp_reader/get_last_file_update` | `entry_id` | ISO8601 timestamp from metadata. |
 | `pp_reader/get_portfolio_data` | `entry_id` | Live portfolio aggregates using `fetch_live_portfolios`. |
 | `pp_reader/get_portfolio_positions` | `entry_id`, `portfolio_uuid` | Detailed positions including gains and holdings. |
-| `pp_reader/get_security_history` | `entry_id`, `security_uuid`, optional `start_date`, `end_date` | Close price series (epoch-day, scaled close) gated by the `pp_reader_history` feature flag. |
+| `pp_reader/get_security_history` | `entry_id`, `security_uuid`, optional `start_date`, `end_date` | Close price series (epoch-day, scaled close) sourced from persisted historical prices. |
 
 All commands default to the coordinator snapshot when live aggregation fails to keep the dashboard responsive. `_live_portfolios_payload` centralises the fetch logic: it queries SQLite via `fetch_live_portfolios` inside an executor, logs and falls back to coordinator snapshots on error, and normalises results before serialising. The accounts endpoint invokes `ensure_exchange_rates_for_dates`/`load_latest_rates` so FX metadata is up to date when non-EUR accounts are present.
 
-Feature flags are resolved through `feature_flags.is_enabled`, which reads overrides from `hass.data[DOMAIN][entry_id]["feature_flags"]` seeded during `async_setup_entry`. When `pp_reader_history` is disabled the history command returns a `feature_not_enabled` error; enabling the flag surfaces deduplicated Close series sourced from `historical_prices`.
+Feature flags are resolved through `feature_flags.is_enabled`, which reads overrides from `hass.data[DOMAIN][entry_id]["feature_flags"]` seeded during `async_setup_entry`. While no flags are currently active, the infrastructure remains available for future experiments without impacting core commands like security history.
 
 The custom panel lives under `www/pp_reader_dashboard`:
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -27,27 +27,7 @@ Additional options (Windows, devcontainers) are documented in [TESTING.md §2](T
 
 ## Feature flags
 
-The integration exposes internal feature toggles to stage backend features before they become generally available. Flags are normalised to lower-case strings and resolved against defaults defined in `feature_flags.py`. Currently the only flag is `pp_reader_history`, which unlocks the WebSocket endpoint returning historical close prices when enabled.【F:custom_components/pp_reader/feature_flags.py†L11-L49】【F:custom_components/pp_reader/data/websocket.py†L408-L453】
-
-### Enabling `pp_reader_history`
-
-Until the options flow surfaces a UI, set the flag through the config entry options stored in `.storage/core.config_entries`:
-
-1. Stop the local Home Assistant instance (`CTRL+C` in the terminal running `./scripts/develop`).
-2. Open `config/.storage/core.config_entries` and locate the object with `"domain": "pp_reader"`.
-3. Inside its `options` mapping add or extend the `feature_flags` section:
-
-   ```json
-   "options": {
-     "feature_flags": {
-       "pp_reader_history": true
-     }
-   }
-   ```
-
-4. Save the file and restart Home Assistant. During setup the integration normalises the options and persists them under `hass.data[DOMAIN][entry_id]["feature_flags"]`, so WebSocket calls can see the flag without further changes.【F:custom_components/pp_reader/__init__.py†L70-L112】【F:custom_components/pp_reader/feature_flags.py†L51-L101】
-
-For ad-hoc experiments you can also toggle the flag at runtime from the Home Assistant developer tools (Python console) by mutating `hass.data["pp_reader"]["<entry_id>"]["feature_flags"]["pp_reader_history"] = True`. This override is ephemeral and resets on the next reload because the config entry options remain the single source of truth.【F:custom_components/pp_reader/feature_flags.py†L51-L101】
+The integration retains a feature-flag infrastructure to stage experimental capabilities when required. Flags are normalised to lower-case strings and resolved against defaults defined in `feature_flags.py`. At the moment no flags are active and all features, including the security history WebSocket command, are enabled by default. When new flags are introduced they can be toggled via the config entry options in `.storage/core.config_entries` using the `feature_flags` mapping.【F:custom_components/pp_reader/feature_flags.py†L11-L101】【F:custom_components/pp_reader/data/websocket.py†L408-L453】
 
 ## Testing & quality checks
 Follow the recommended pipeline before submitting a PR: lint, run targeted tests, then run the full suite with coverage and optional hassfest.【F:AGENTS.md†L13-L15】【F:TESTING.md†L20-L96】


### PR DESCRIPTION
## Summary
- update README-dev.md to describe the feature flag framework without the retired pp_reader_history switch
- refresh Architecture.md to note history access is always available and document the flag infrastructure generically
- mark the documentation cleanup task as complete in the security detail tab checklist

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db8460883c8330b4774716b2223179