### PR TITLE
Add security snapshot and history API helpers

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -37,7 +37,7 @@
       - Ziel: Sicherstellen, dass Snapshot-Handler und History-Handler ohne Flag funktionieren
 
 3. Frontend: API-Schicht aktualisieren
-   a) [ ] Ergänze `fetchSecuritySnapshotWS` und `fetchSecurityHistoryWS`
+   a) [x] Ergänze `fetchSecuritySnapshotWS` und `fetchSecurityHistoryWS`
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js`
       - Abschnitt/Funktion: WebSocket-Hilfsfunktionen
       - Ziel: Liefert Promise-basierte Wrapper für neue/aktualisierte Backend-Kommandos

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js
@@ -90,3 +90,65 @@ export async function fetchPortfolioPositionsWS(hass, panelConfig, portfolio_uui
     portfolio_uuid,
   });
 }
+
+// Security snapshot for detail tab
+export async function fetchSecuritySnapshotWS(
+  hass,
+  panelConfig,
+  securityUuid,
+) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(
+      `fetchSecuritySnapshotWS: fehlendes hass oder entry_id (${entry_id})`,
+    );
+  }
+  if (!securityUuid) {
+    throw new Error("fetchSecuritySnapshotWS: fehlendes securityUuid");
+  }
+
+  return await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_security_snapshot",
+    entry_id,
+    security_uuid: securityUuid,
+  });
+}
+
+// Historical prices for detail tab charting
+export async function fetchSecurityHistoryWS(
+  hass,
+  panelConfig,
+  securityUuid,
+  options = {},
+) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(
+      `fetchSecurityHistoryWS: fehlendes hass oder entry_id (${entry_id})`,
+    );
+  }
+  if (!securityUuid) {
+    throw new Error("fetchSecurityHistoryWS: fehlendes securityUuid");
+  }
+
+  const payload = {
+    type: "pp_reader/get_security_history",
+    entry_id,
+    security_uuid: securityUuid,
+  };
+
+  const { startDate, endDate, start_date: start_date_raw, end_date: end_date_raw } =
+    options || {};
+
+  const resolvedStart = startDate ?? start_date_raw;
+  if (resolvedStart !== undefined && resolvedStart !== null) {
+    payload.start_date = resolvedStart;
+  }
+
+  const resolvedEnd = endDate ?? end_date_raw;
+  if (resolvedEnd !== undefined && resolvedEnd !== null) {
+    payload.end_date = resolvedEnd;
+  }
+
+  return await hass.connection.sendMessagePromise(payload);
+}


### PR DESCRIPTION
## Summary
- add websocket API helpers to fetch security snapshots and history data for the dashboard
- support optional start and end date arguments when requesting history ranges
- validate Home Assistant context, entry id, and security uuid before issuing WebSocket requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db8f6b47608330bb06ca1ecc520ed1