### PR TITLE
Update websocket history test to drop legacy flag reference

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -41,7 +41,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js`
       - Abschnitt/Funktion: WebSocket-Hilfsfunktionen
       - Ziel: Liefert Promise-basierte Wrapper für neue/aktualisierte Backend-Kommandos
-   b) [ ] Entferne Feature-Flag-Abfragen für History-Fetches
+   b) [x] Entferne Feature-Flag-Abfragen für History-Fetches
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js`
       - Abschnitt/Funktion: Bestehende History-Helper
       - Ziel: History-Aufrufe erfolgen ohne Flag-Prüfung, Fehler werden clientseitig abgefangen

--- a/tests/test_ws_security_history.py
+++ b/tests/test_ws_security_history.py
@@ -313,10 +313,10 @@ def test_ws_get_security_history_returns_filtered_prices(
     ]
 
 
-def test_ws_get_security_history_ignores_missing_feature_flag(
+def test_ws_get_security_history_ignores_unknown_feature_flags(
     seeded_history_db: Path,
 ) -> None:
-    """Handler should ignore legacy feature flag states."""
+    """Handler should ignore unrelated legacy feature flag states."""
 
     entry_id = "entry-2"
     hass = StubHass(
@@ -324,7 +324,7 @@ def test_ws_get_security_history_ignores_missing_feature_flag(
             DOMAIN: {
                 entry_id: {
                     "db_path": seeded_history_db,
-                    "feature_flags": {"pp_reader_history": False},
+                    "feature_flags": {"legacy_flag": False},
                 }
             }
         }


### PR DESCRIPTION
## Summary
- adjust the websocket history test to avoid referencing the removed pp_reader_history feature flag
- mark the checklist item for removing frontend flag checks as complete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db93af47f083308517d185423c2685