### PR TITLE
Refactor dashboard tabs for detail registry

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -47,7 +47,7 @@
       - Ziel: History-Aufrufe erfolgen ohne Flag-Prüfung, Fehler werden clientseitig abgefangen
 
 4. Frontend: Dashboard-Tab-Verwaltung refaktorieren
-   a) [ ] Ersetze statisches `tabs`-Array durch Registry mit dynamischen Detail-Tabs
+   a) [x] Ersetze statisches `tabs`-Array durch Registry mit dynamischen Detail-Tabs
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js`
       - Abschnitt/Funktion: Tab-Initialisierung und Navigation
       - Ziel: Ermöglicht Hinzufügen/Entfernen von Security-Detail-Tabs und entfernt Test-Tab


### PR DESCRIPTION
## Summary
- replace the dashboard tab list with a registry that supports dynamic detail tabs
- expose helpers for registering and removing detail tabs ahead of security detail integration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba3e026e48330b9a7666678114a2f