### PR TITLE
Add cache helpers for security snapshots

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -69,7 +69,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js`
       - Abschnitt/Funktion: Event-Listener nach Lazy-Load
       - Ziel: Öffnet Security-Detail-Tab und ignoriert Klicks auf Expand/Collapse-Buttons
-   b) [ ] Stelle sicher, dass `portfolioPositionsCache` Security-Daten bereitstellt
+   b) [x] Stelle sicher, dass `portfolioPositionsCache` Security-Daten bereitstellt
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js`
       - Abschnitt/Funktion: Cache-Verwaltung
       - Ziel: Übergibt Snapshot-Daten oder löst Fallback-Fetch über Dashboard-Controller aus


### PR DESCRIPTION
## Summary
- add helper functions to aggregate cached positions per security for the upcoming detail tab
- attach the helpers to the portfolio positions cache and expose them globally for reuse
- mark the checklist item for cache preparation as complete

## Testing
- not run (frontend change only)

------
https://chatgpt.com/codex/tasks/task_e_68dbb119d0dc83308e94c9c3c326171b