### PR TITLE
Update security detail header to show native price

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -79,7 +79,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Neuer Renderer und Tab-Registrierung
       - Ziel: Baut Header, lädt Daten, verbindet mit Navigation
-   b) [ ] Render Header-Karten (Name, Currency, Holdings, Last Price in Originalwährung, Market Value in EUR) mit vorhandenen Formattern
+   b) [x] Render Header-Karten (Name, Currency, Holdings, Last Price in Originalwährung, Market Value in EUR) mit vorhandenen Formattern
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Header-Rendering
       - Ziel: Konsistentes Kartenlayout zur Overview und zeigt Währungsinformationen korrekt an

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
@@ -12,6 +12,10 @@ const HOLDINGS_FRACTION_DIGITS = { min: 0, max: 6 };
 const PRICE_FRACTION_DIGITS = { min: 2, max: 4 };
 
 function formatHoldings(value) {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+
   const numeric = Number.isFinite(value) ? value : Number.parseFloat(value) || 0;
   const hasFraction = Math.abs(numeric % 1) > 0;
   const minFraction = hasFraction ? 2 : HOLDINGS_FRACTION_DIGITS.min;
@@ -23,6 +27,10 @@ function formatHoldings(value) {
 }
 
 function formatPrice(value) {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+
   const numeric = Number.isFinite(value) ? value : Number.parseFloat(value) || 0;
   return numeric.toLocaleString('de-DE', {
     minimumFractionDigits: PRICE_FRACTION_DIGITS.min,
@@ -36,8 +44,14 @@ function buildHeaderMeta(snapshot) {
   }
 
   const currency = snapshot.currency_code || 'EUR';
-  const holdings = formatHoldings(snapshot.total_holdings ?? 0);
-  const lastPriceEur = formatPrice(snapshot.last_price_eur ?? 0);
+  const holdings = formatHoldings(snapshot.total_holdings);
+  const lastPriceNative =
+    snapshot.last_price_native ?? snapshot.last_price?.native ?? snapshot.last_price_eur;
+  const formattedLastPrice = formatPrice(lastPriceNative);
+  const lastPriceDisplay =
+    formattedLastPrice === '—'
+      ? '—'
+      : `${formattedLastPrice}${currency ? `&nbsp;${currency}` : ''}`;
   const marketValue = formatNumber(snapshot.market_value_eur ?? 0);
 
   return `
@@ -51,8 +65,8 @@ function buildHeaderMeta(snapshot) {
         <span class="value">${holdings}</span>
       </div>
       <div class="security-meta-item">
-        <span class="label">Letzter Preis (EUR)</span>
-        <span class="value">${lastPriceEur}&nbsp;€</span>
+        <span class="label">Letzter Preis (${currency})</span>
+        <span class="value">${lastPriceDisplay}</span>
       </div>
       <div class="security-meta-item">
         <span class="label">Marktwert (EUR)</span>


### PR DESCRIPTION
## Summary
- show native-currency price information in the security detail header
- harden holdings and price formatting against missing snapshot values
- mark the checklist item for header cards as complete

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbb990c29c83309d917af44dfac923