### PR TITLE
Add range selector controls for security detail history

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -87,7 +87,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Rendering & Datenaggregation für Infoleiste
       - Ziel: Verbindet Kursbewegungen in Originalwährung mit Portfolioauswirkung in EUR
-   d) [ ] Implementiere Range-Buttons (1M, 6M, 1Y default, 5Y)
+   d) [x] Implementiere Range-Buttons (1M, 6M, 1Y default, 5Y)
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: State-Management für Range-Auswahl
       - Ziel: Löst History-Fetch aus, markiert aktive Range und cached Antworten pro Range


### PR DESCRIPTION
## Summary
- add range selector buttons to the security detail tab and wire them to history fetches
- cache fetched history series per security/range and update info bar + placeholder content on selection
- mark the checklist item for range buttons as completed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc0feafec833080aa51f215c0d96a