### PR TITLE
Add security history error and empty states

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -91,7 +91,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: State-Management für Range-Auswahl
       - Ziel: Löst History-Fetch aus, markiert aktive Range und cached Antworten pro Range
-   e) [ ] Baue Fehler- und Empty-State-Anzeige bei fehlender History
+   e) [x] Baue Fehler- und Empty-State-Anzeige bei fehlender History
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Fehlerbehandlung
       - Ziel: Zeigt freundliche Nachricht statt Chart bei fehlenden Daten


### PR DESCRIPTION
## Summary
- show specific empty and error placeholders for security history ranges
- propagate history load state when fetching and caching range data
- normalise WebSocket errors for friendly display in the detail tab

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbc6c1a7088330b5d0817dc80c99a4