### PR TITLE
Invalidate security history cache on live updates

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -95,7 +95,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Fehlerbehandlung
       - Ziel: Zeigt freundliche Nachricht statt Chart bei fehlenden Daten
-   f) [ ] Invaldiere Range-Caches bei Live-Updates des aktiven `security_uuid`
+   f) [x] Invaldiere Range-Caches bei Live-Updates des aktiven `security_uuid`
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Subscription auf Push-Events
       - Ziel: Sicherstellt aktuelle Chartdaten nach Preis-Updates


### PR DESCRIPTION
## Summary
- broadcast portfolio position updates with the affected security UUIDs
- subscribe the security detail tab to live updates and clear cached history for matching securities
- tick the checklist item covering live-update driven cache invalidation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbce8997988330b499a1de840fd799