### PR TITLE
Cache security detail history data across sessions

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -115,7 +115,7 @@
       - Ziel: Konsistentes Erscheinungsbild mit bestehendem Dashboard-Styling
 
 8. State- und Cache-Management
-   a) [ ] Cache History-Daten pro Range und Security im Frontend
+   a) [x] Cache History-Daten pro Range und Security im Frontend
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js`
       - Abschnitt/Funktion: Lokaler State/Cache
       - Ziel: Verhindert redundante WebSocket-Aufrufe bei Range-Wechseln


### PR DESCRIPTION
## Summary
- reuse cached history series when reopening a security detail tab to avoid redundant websocket calls
- skip caching failed history fetches while still updating initial range state handling
- update checklist to mark the caching task as complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdbcda0fc8330be391807d3238156