### PR TITLE
Document manual navigation validation for security detail tab

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -143,7 +143,7 @@
        - Datei: `tests/test_ws_security_history.py`
        - Abschnitt/Funktion: Bestehende Testklasse erweitern
        - Ziel: Sicherstellen, dass Backend Start/Ende korrekt berechnet und Antworten cached
-    b) [ ] Ergänze Frontend-Test (falls Harness vorhanden) oder dokumentiere manuelle Swipe/Pfeil-Prüfung
+    b) [x] Ergänze Frontend-Test (falls Harness vorhanden) oder dokumentiere manuelle Swipe/Pfeil-Prüfung
        - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/__tests__/dashboard.test.js` (falls vorhanden) oder `.docs/manual_test_security_detail.md`
        - Abschnitt/Funktion: Navigationstestfälle
        - Ziel: Verifiziert Navigation zwischen Overview- und Detail-Tabs

--- a/.docs/manual_test_security_detail.md
+++ b/.docs/manual_test_security_detail.md
@@ -23,11 +23,12 @@
 3. Click on a position row (avoiding expand toggles) to open the security detail tab.
 4. Confirm that header cards display expected values matching the Portfolio Performance dataset.
 5. Observe the chart render with the default range (1Y). Hover to confirm tooltip accuracy for dates and prices.
-6. Click each range button (1M, 6M, 1Y, 5Y) and verify active state styling and chart refresh behaviour.
-7. If historical data is absent, ensure the empty-state banner appears and no chart is drawn.
-8. Trigger or wait for a live price update, then verify that header and chart data refresh automatically.
-9. Close the tab using the provided control and confirm the overview remains in its prior state.
-10. Review the browser console for warnings or errors; none should be present.
+6. Use the tab-strip arrow buttons to navigate back to the overview and forward to the detail tab again. Verify that the active tab indicator follows each navigation step and that swipe gestures on touch devices mirror the arrow-button behaviour.
+7. Click each range button (1M, 6M, 1Y, 5Y) and verify active state styling and chart refresh behaviour.
+8. If historical data is absent, ensure the empty-state banner appears and no chart is drawn.
+9. Trigger or wait for a live price update, then verify that header and chart data refresh automatically.
+10. Close the tab using the provided control and confirm the overview remains in its prior state.
+11. Review the browser console for warnings or errors; none should be present.
 
 ## Pass/Fail Criteria
 - All scenarios in the matrix complete without UI or console errors.


### PR DESCRIPTION
## Summary
- expand the security detail manual test plan with explicit arrow and swipe navigation validation steps
- mark the TODO checklist item for documenting manual navigation checks as complete

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc02be8b7883308d431046ddbedcec