### PR TITLE
chore: remove unused sync import

### DIFF
--- a/.docs/TODO_security_detail_tab.md
+++ b/.docs/TODO_security_detail_tab.md
@@ -159,7 +159,7 @@
        - Dateien: `custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js`, zugehörige Templates/Strings
        - Abschnitt/Funktion: Tab-Registrierung und Übersetzungen
        - Ziel: Kein Legacy-Test-Tab mehr sichtbar
-    b) [ ] Bereinige ungenutzte Imports nach Refactoring
+    b) [x] Bereinige ungenutzte Imports nach Refactoring
        - Dateien: Alle betroffenen JS/Python-Dateien
        - Abschnitt/Funktion: Kopfbereiche der Dateien
        - Ziel: Sauberer Build ohne Lint-Warnungen

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional


### PR DESCRIPTION
## Summary
- remove the unused Mapping import from the Portfolio Performance sync helper
- mark the clean-up checklist item as complete

## Testing
- `ruff check --select F401`


------
https://chatgpt.com/codex/tasks/task_e_68dc0b3a459c8330babf0abd77acf9a9