### PR TITLE
Ensure dev setup scripts expose config at /config

### DIFF
--- a/scripts/develop
+++ b/scripts/develop
@@ -5,9 +5,27 @@ set -e
 cd "$(dirname "$0")/.."
 
 # Create config dir if not present
-if [[ ! -d "${PWD}/config" ]]; then
-    mkdir -p "${PWD}/config"
-    hass --config "${PWD}/config" --script ensure_config
+CONFIG_DIR="${PWD}/config"
+if [[ ! -d "${CONFIG_DIR}" ]]; then
+    mkdir -p "${CONFIG_DIR}"
+    hass --config "${CONFIG_DIR}" --script ensure_config
+fi
+
+# Home Assistant integrations commonly expect the configuration directory to
+# be available at "/config" (matching the official container image).  Our
+# development checkout keeps the files under <repo>/config, so ensure a
+# symlink exists so absolute paths stored in config entries keep working.
+if [[ ! -e "/config" ]]; then
+    ln -s "${CONFIG_DIR}" /config
+elif [[ -L "/config" ]]; then
+    current_target="$(readlink /config)"
+    if [[ "${current_target}" != "${CONFIG_DIR}" ]]; then
+        rm /config
+        ln -s "${CONFIG_DIR}" /config
+    fi
+elif [[ ! -d "/config" ]]; then
+    echo "Refusing to overwrite /config because it exists and is not a symlink" >&2
+    exit 1
 fi
 
 # Set the path to custom_components

--- a/scripts/setup
+++ b/scripts/setup
@@ -5,3 +5,21 @@ set -e
 cd "$(dirname "$0")/.."
 
 python3 -m pip install --requirement requirements.txt
+
+CONFIG_DIR="${PWD}/config"
+if [ ! -d "${CONFIG_DIR}" ]; then
+    mkdir -p "${CONFIG_DIR}"
+fi
+
+if [ ! -e "/config" ]; then
+    ln -s "${CONFIG_DIR}" /config
+elif [ -L "/config" ]; then
+    current_target="$(readlink /config)"
+    if [ "${current_target}" != "${CONFIG_DIR}" ]; then
+        rm /config
+        ln -s "${CONFIG_DIR}" /config
+    fi
+elif [ ! -d "/config" ]; then
+    echo "Refusing to overwrite /config because it exists and is not a symlink" >&2
+    exit 1
+fi

--- a/scripts/setup_container
+++ b/scripts/setup_container
@@ -24,8 +24,22 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install --requirement requirements.txt
 
-if [ ! -d "config" ]; then
-    mkdir -p "config"
+CONFIG_DIR="${PWD}/config"
+if [ ! -d "${CONFIG_DIR}" ]; then
+    mkdir -p "${CONFIG_DIR}"
+fi
+
+if [ ! -e "/config" ]; then
+    ln -s "${CONFIG_DIR}" /config
+elif [ -L "/config" ]; then
+    current_target="$(readlink /config)"
+    if [ "${current_target}" != "${CONFIG_DIR}" ]; then
+        rm /config
+        ln -s "${CONFIG_DIR}" /config
+    fi
+elif [ ! -d "/config" ]; then
+    echo "Refusing to overwrite /config because it exists and is not a symlink" >&2
+    exit 1
 fi
 
 echo "Setup complete. Run ./scripts/develop to start Home Assistant."


### PR DESCRIPTION
## Summary
- ensure the development scripts create a /config symlink pointing to the repo config directory so absolute paths resolve during Home Assistant runs
- update setup, setup_container, and develop scripts to reuse the repository config directory when creating the link

## Testing
- ./scripts/setup

------
https://chatgpt.com/codex/tasks/task_e_68dd124f4ff48330a47337839644670d