### PR TITLE
Handle invalid backup filenames during cleanup

### DIFF
--- a/custom_components/pp_reader/data/backup_db.py
+++ b/custom_components/pp_reader/data/backup_db.py
@@ -200,12 +200,25 @@ def cleanup_old_backups(backup_dir: Path) -> None:
     weekly = {}
 
     for b in backups:
+        stem_parts = b.stem.rsplit("_", 2)
+        if len(stem_parts) < 3:
+            _LOGGER.debug(
+                "⏭️ Überspringe Backup mit unerwartetem Dateinamen: %s", b.name
+            )
+            continue
+
+        dt_str = "_".join(stem_parts[-2:])  # 20250430_143000
+
         try:
-            dt_str = "_".join(b.stem.split("_")[-2:])  # 20250430_1430
             dt = datetime.strptime(dt_str, "%Y%m%d_%H%M%S")  # noqa: DTZ007
         except ValueError as exc:
-            # Replace ValueError with the specific exception expected
-            _LOGGER.warning("⚠️ Fehler beim Verarbeiten des Backups: %s", exc)
+            _LOGGER.debug(
+                "⏭️ Überspringe Backup %s wegen ungültigem Zeitstempel '%s': %s",
+                b.name,
+                dt_str,
+                exc,
+            )
+            continue
 
         key = dt.date()
         age = (now - dt).days  # Alter des Backups in Tagen berechnen

--- a/tests/test_backup_cleanup.py
+++ b/tests/test_backup_cleanup.py
@@ -1,0 +1,37 @@
+"""Tests for the backup cleanup helper."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+
+from custom_components.pp_reader.data.backup_db import cleanup_old_backups
+
+
+def test_cleanup_skips_invalid_backups(tmp_path, caplog) -> None:
+    """Ensure cleanup ignores backups with unexpected file names."""
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+
+    # Create an invalid backup file that cannot be parsed.
+    invalid_backup = backup_dir / "invalid.db"
+    invalid_backup.write_text("not a real backup")
+
+    # Create a valid backup using the current timestamp so it is never pruned.
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    valid_backup = backup_dir / f"S-Depot_{timestamp}.db"
+    valid_backup.write_text("valid backup")
+
+    # Run cleanup and capture warnings.
+    with caplog.at_level(
+        logging.WARNING, logger="custom_components.pp_reader.data.backup_db"
+    ):
+        cleanup_old_backups(backup_dir)
+
+    # No warnings should have been emitted for the invalid backup.
+    assert not caplog.records
+
+    # The valid backup is kept and the invalid one is removed during cleanup.
+    assert not invalid_backup.exists()
+    assert valid_backup.exists()


### PR DESCRIPTION
## Summary
- skip unexpected backup filenames in the cleanup routine instead of emitting warnings
- add a regression test to ensure invalid backup files are ignored and removed cleanly

## Testing
- pytest tests/test_backup_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68dd47e9a59883308cdac862873d574d