### PR TITLE
Fix dashboard render lookup for panel shadow DOM

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
@@ -157,8 +157,29 @@ function getSecurityDetailTabKey(securityUuid) {
   return `${SECURITY_DETAIL_TAB_PREFIX}${securityUuid}`;
 }
 
+function findDashboardElement() {
+  const direct = document.querySelector('pp-reader-dashboard');
+  if (direct) {
+    return direct;
+  }
+
+  const panelElements = document.querySelectorAll('pp-reader-panel');
+  for (const panelElement of panelElements) {
+    if (!panelElement || !panelElement.shadowRoot) {
+      continue;
+    }
+
+    const nested = panelElement.shadowRoot.querySelector('pp-reader-dashboard');
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
 function requestDashboardRender() {
-  const dashboardElement = document.querySelector('pp-reader-dashboard');
+  const dashboardElement = findDashboardElement();
   if (!dashboardElement) {
     console.warn('requestDashboardRender: Kein pp-reader-dashboard Element gefunden');
     return;


### PR DESCRIPTION
## Summary
- ensure dashboard re-rendering finds the element inside the panel's shadow DOM

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dd91ab5e448330b7bedb22f79bba10