### PR TITLE
Fix security detail tab rendering in Portfolio Performance panel

### DIFF
--- a/custom_components/pp_reader/__init__.py
+++ b/custom_components/pp_reader/__init__.py
@@ -288,6 +288,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
             hass, websocket.ws_get_portfolio_data_handler
         )
         websocket_api.async_register_command(hass, websocket.ws_get_portfolio_positions)
+        websocket_api.async_register_command(hass, websocket.ws_get_security_snapshot)
         websocket_api.async_register_command(hass, websocket.ws_get_security_history)
         # _LOGGER.debug("✅ Websocket-Befehle erfolgreich registriert.")  # noqa: ERA001
     except TypeError:

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
@@ -158,6 +158,15 @@ function getSecurityDetailTabKey(securityUuid) {
 }
 
 function findDashboardElement() {
+  const registered = window.__ppReaderDashboardElements;
+  if (registered instanceof Set) {
+    for (const element of registered) {
+      if (element && element.isConnected) {
+        return element;
+      }
+    }
+  }
+
   const direct = document.querySelector('pp-reader-dashboard');
   if (direct) {
     return direct;

--- a/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
@@ -31,6 +31,23 @@ class PPReaderPanel extends HTMLElement {
       console.error("[pp_reader] Dashboard Element nicht gefunden – Rendering unmöglich.");
     } else {
       console.debug("[pp_reader] Dashboard Element referenziert.");
+      try {
+        if (!window.__ppReaderDashboardElements) {
+          window.__ppReaderDashboardElements = new Set();
+        }
+        window.__ppReaderDashboardElements.add(this._dashboardEl);
+      } catch (error) {
+        console.warn('[pp_reader] Konnte Dashboard-Referenz nicht registrieren', error);
+      }
+    }
+
+    try {
+      if (!window.__ppReaderPanelHosts) {
+        window.__ppReaderPanelHosts = new Set();
+      }
+      window.__ppReaderPanelHosts.add(this);
+    } catch (error) {
+      console.warn('[pp_reader] Konnte Panel-Instanz nicht verfolgen', error);
     }
 
     container.querySelector('.menu-button').addEventListener('click', () => {
@@ -100,6 +117,12 @@ class PPReaderPanel extends HTMLElement {
   disconnectedCallback() {
     if (this._resizeObserver) {
       this._resizeObserver.disconnect();
+    }
+    if (window.__ppReaderPanelHosts instanceof Set) {
+      window.__ppReaderPanelHosts.delete(this);
+    }
+    if (window.__ppReaderDashboardElements instanceof Set && this._dashboardEl) {
+      window.__ppReaderDashboardElements.delete(this._dashboardEl);
     }
   }
 }


### PR DESCRIPTION
## Summary
- register the pp_reader security snapshot websocket command during setup so the frontend can request detail data
- track panel dashboard elements globally when the custom element is instantiated and cleaned up
- let the dashboard lookup reuse the registered element references to re-render detail tabs inside Home Assistant’s nested shadow DOM

## Testing
- pytest tests/test_ws_security_history.py


------
https://chatgpt.com/codex/tasks/task_e_68dd94d3c60c83309f539a07447e0a89