### PR TITLE
Fix security detail snapshot parsing

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
@@ -401,7 +401,19 @@ export async function renderSecurityDetail(root, hass, panelConfig, securityUuid
   let error = null;
 
   try {
-    snapshot = await fetchSecuritySnapshotWS(hass, panelConfig, securityUuid);
+    const response = await fetchSecuritySnapshotWS(
+      hass,
+      panelConfig,
+      securityUuid,
+    );
+    if (response && typeof response === 'object') {
+      snapshot =
+        response.snapshot && typeof response.snapshot === 'object'
+          ? response.snapshot
+          : response;
+    } else {
+      snapshot = response;
+    }
   } catch (err) {
     console.error('renderSecurityDetail: Snapshot konnte nicht geladen werden', err);
     error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- correctly unwrap the security snapshot payload returned by the websocket API before rendering the detail view
- keep compatibility with legacy payloads and ensure header metrics display the fetched holdings and price information

## Testing
- playwright script to log in, open a security detail tab, and capture the header values

------
https://chatgpt.com/codex/tasks/task_e_68de105be74c833093241d0774b6b494