### PR TITLE
Fix duplicate sticky anchor creation in dashboard

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/nav.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/nav.css
@@ -57,7 +57,7 @@
   transform: scale(1.25);
 }
 
-#anchor {
+#pp-reader-sticky-anchor {
   height: 1px;
   position: relative;
   top: 1rem;

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
@@ -9,6 +9,8 @@ import {
 } from './data/updateConfigsWS.js';
 import { getEntryId } from './data/api.js';
 
+const STICKY_HEADER_ANCHOR_ID = 'pp-reader-sticky-anchor';
+
 const OVERVIEW_TAB_KEY = 'overview';
 
 const baseTabs = [
@@ -353,11 +355,11 @@ async function renderTab(root, hass, panel) {
     return;
   }
 
-  // #anchor erstellen und vor der header-card platzieren
-  let anchor = document.getElementById('anchor');
+  // Sticky-Anchor für IntersectionObserver erstellen (scoped innerhalb des Root-Elements)
+  let anchor = root.querySelector(`#${STICKY_HEADER_ANCHOR_ID}`);
   if (!anchor) {
     anchor = document.createElement('div');
-    anchor.id = 'anchor';
+    anchor.id = STICKY_HEADER_ANCHOR_ID;
     headerCard.parentNode.insertBefore(anchor, headerCard);
   }
 
@@ -370,7 +372,7 @@ async function renderTab(root, hass, panel) {
 function setupHeaderScrollBehavior(root) {
   const headerCard = root.querySelector('.header-card');
   const scrollBorder = root;
-  const anchor = root.querySelector('#anchor');
+  const anchor = root.querySelector(`#${STICKY_HEADER_ANCHOR_ID}`);
 
   if (!headerCard || !scrollBorder || !anchor) {
     console.error("Fehlende Elemente für das Scrollverhalten: headerCard, scrollBorder oder anchor.");


### PR DESCRIPTION
## Summary
- ensure the sticky header anchor is managed within the dashboard root to avoid duplicate IDs after re-rendering
- update the CSS selector to match the new scoped anchor id

## Testing
- python - <<'PY' ... (Playwright script checking anchor count)


------
https://chatgpt.com/codex/tasks/task_e_68de1ef5c0e883309041bf3b3a8c0513