### PR TITLE
Preserve gain styling after live portfolio updates

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
@@ -305,8 +305,12 @@ export function handlePortfolioUpdate(update, root) {
       row.classList.add('flash-update');
       setTimeout(() => row.classList.remove('flash-update'), 800);
     }
-    if (gainAbsCell) gainAbsCell.textContent = formatNumber(gainAbs) + ' €';
-    if (gainPctCell) gainPctCell.textContent = formatNumber(gainPct) + ' %';
+    if (gainAbsCell) {
+      gainAbsCell.innerHTML = formatGain(gainAbs);
+    }
+    if (gainPctCell) {
+      gainPctCell.innerHTML = formatGainPct(gainPct);
+    }
 
     row.dataset.positionCount = String(posCount);
     row.dataset.currentValue = String(curVal);


### PR DESCRIPTION
## Summary
- keep the positive/negative gain styling when websocket portfolio updates patch existing rows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1ef5c0e883309041bf3b3a8c0513