### PR TITLE
Fix PP reader panel entry id fallback

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js
@@ -1,6 +1,14 @@
 function deriveEntryId(hass, panelConfig) {
-  // Direkt gesetzte einfache Variante
+  // Direkt gesetzte einfache Variante (neuer Panelspeicher)
   let entry_id = panelConfig?.config?.entry_id;
+
+  // Neu: Home Assistant liefert den entry_id-Wert inzwischen auch auf Root-Ebene
+  // des panelConfig-Objekts. Ohne diesen Fallback konnten wir in seltenen Fällen
+  // keinen entry_id bestimmen (z.B. wenn hass.panels noch nicht gefüllt war),
+  // wodurch sämtliche Websocket-Aufrufe mit "fehlendes hass oder entry_id" brachen.
+  if (!entry_id) {
+    entry_id = panelConfig?.entry_id;
+  }
 
   // Legacy verschachtelte Struktur (panel_custom)
   if (!entry_id) {


### PR DESCRIPTION
## Summary
- ensure the frontend resolves the PP Reader panel entry_id from the top-level panelConfig object before falling back to hass.panels

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de2edfca948330bc5047c0e04375dd