### PR TITLE
Indicate cached security detail snapshot values

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -130,6 +130,21 @@
   margin-top: 1rem;
 }
 
+.card.warning-card {
+  border-left: 4px solid var(--warning-color, #f0ad4e);
+  background-color: rgba(240, 173, 78, 0.12);
+}
+
+.card.warning-card h2 {
+  color: var(--warning-color, #f0ad4e);
+  margin-top: 0;
+}
+
+.card.warning-card p {
+  margin: 0.25rem 0;
+  color: var(--primary-text-color);
+}
+
 .meta {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a warning card to the security detail tab whenever cached snapshot data is shown
- style warning cards so cached notices stand out from normal content

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de2edfca948330bc5047c0e04375dd