### PR TITLE
Preserve security detail range selection

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
@@ -487,7 +487,7 @@ export async function renderSecurityDetail(root, hass, panelConfig, securityUuid
     `;
   }
 
-  const activeRange = DEFAULT_HISTORY_RANGE;
+  const activeRange = getActiveRange(securityUuid);
   const cache = ensureHistoryCache(securityUuid);
   let historySeries = cache.has(activeRange) ? cache.get(activeRange) : null;
   let historyState = { status: 'empty' };


### PR DESCRIPTION
## Summary
- ensure the security detail tab restores the previously selected history range when re-rendering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de3d19b82c8330a4e8768432a5547d