### PR TITLE
Fix redundant pp_reader dashboard renders

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
@@ -489,6 +489,9 @@ class PPReaderDashboard extends HTMLElement {
   }
 
   set panel(panel) {
+    if (this._panel === panel) {
+      return;
+    }
     this._panel = panel;
     // Debug
     // console.debug("PPReaderDashboard: panel setter", panel);
@@ -496,11 +499,17 @@ class PPReaderDashboard extends HTMLElement {
   }
 
   set narrow(narrow) {
+    if (this._narrow === narrow) {
+      return;
+    }
     this._narrow = narrow;
     this._renderIfInitialized(); // Rendere nur, wenn initialisiert
   }
 
   set route(route) {
+    if (this._route === route) {
+      return;
+    }
     this._route = route;
     this._renderIfInitialized(); // Rendere nur, wenn initialisiert
   }


### PR DESCRIPTION
## Summary
- queue dashboard property updates from the panel to coalesce multiple setter invocations into a single pass
- skip re-rendering in the dashboard when panel, route, or narrow values are unchanged to prevent redundant websocket fetches

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de6e58004c83309c4226db135d03c2