### PR TITLE
Fix detail tab lingering after navigating back

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.js
@@ -57,8 +57,21 @@ function clampPageIndex(index) {
 }
 
 async function navigateToPage(targetIndex, root, hass, panel) {
+  const tabs = getVisibleTabs();
   const clampedIndex = clampPageIndex(targetIndex);
   if (clampedIndex === currentPage) {
+    return;
+  }
+
+  const currentTab = tabs[currentPage];
+  const targetTab = tabs[clampedIndex];
+  const currentSecurityUuid = extractSecurityUuidFromKey(currentTab?.key);
+
+  if (
+    currentSecurityUuid &&
+    targetTab?.key === OVERVIEW_TAB_KEY &&
+    closeSecurityDetail(currentSecurityUuid)
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- close active security detail tabs when navigating back to the overview
- prevent the next-tab arrow from staying enabled after leaving a detail view

## Testing
- Manual Playwright check of opening a security, navigating back, and ensuring the next arrow is disabled

------
https://chatgpt.com/codex/tasks/task_e_68de6e58004c83309c4226db135d03c2