### PR TITLE
Fix duplicate dashboard module loading for PP Reader panel

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.module.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.module.js
@@ -1,0 +1,4 @@
+// Entry module to ensure a single specifier is used when importing the dashboard controller.
+// This keeps the versioned module identifier in one place and avoids duplicate evaluations
+// caused by mismatched cache-busting query parameters.
+export * from './dashboard.js?v=20250914b';

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
@@ -1,5 +1,5 @@
 import { createHeaderCard, makeTable, formatNumber, formatGain, formatGainPct } from '../content/elements.js';
-import { openSecurityDetail } from '../dashboard.js';
+import { openSecurityDetail } from '../dashboard.module.js';
 import { fetchAccountsWS, fetchLastFileUpdateWS, fetchPortfoliosWS, fetchPortfolioPositionsWS } from '../data/api.js';
 import { flushPendingPositions, flushAllPendingPositions } from '../data/updateConfigsWS.js';
 

--- a/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
@@ -1,4 +1,4 @@
-import './js/dashboard.js?v=20250914b'; // Cache-Bust Version
+import './js/dashboard.module.js';
 
 const ASSET_BASE_URL = new URL('./', import.meta.url);
 


### PR DESCRIPTION
## Summary
- add a versioned dashboard entry module so every consumer imports the same specifier
- switch panel and overview code to load the dashboard controller through the shared entry to prevent duplicate evaluation and console spam

## Testing
- playwright script to log in and open the Portfolio Dashboard panel

------
https://chatgpt.com/codex/tasks/task_e_68de7a4bb6e88330a11b4c61e8590cfd