### PR TITLE
Preserve security detail range selection

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/security_detail.js
@@ -149,7 +149,8 @@ function cleanupSecurityDetailState(securityUuid) {
 
   removeLiveUpdateSubscription(securityUuid);
   invalidateHistoryCache(securityUuid);
-  RANGE_STATE_REGISTRY.delete(securityUuid);
+  // RANGE_STATE_REGISTRY intentionally left intact so the last chosen
+  // range remains active when the user reopens the security detail.
 }
 
 function setActiveRange(securityUuid, rangeKey) {


### PR DESCRIPTION
## Summary
- keep the chosen history range for a security detail when the tab is closed and reopened
- document the intent in the cleanup helper to clarify why the range state persists

## Testing
- manual verification: open a security, switch to the 6M range, navigate back to the overview and reopen the security to confirm the 6M button remains active

------
https://chatgpt.com/codex/tasks/task_e_68de88f221d08330b82b7eba0b640075