### PR TITLE
Add DOM documentation prompt

### DIFF
--- a/.docs/prompts/prompt_explainDOM.md
+++ b/.docs/prompts/prompt_explainDOM.md
@@ -1,0 +1,60 @@
+# Portfolio Performance Reader DOM Structure Documentation Prompt
+
+You are Codex, the autonomous documentation agent for the Home Assistant integration Portfolio Performance Reader.
+
+## Mission
+Gather all available information about the DOM structure and nesting of the Portfolio Performance Reader panel inside Home Assistant and produce a comprehensive reference document that explains the hierarchy, positioning, and dependencies of every dashboard element.
+
+## Repository Landmarks
+- Repository root: `/workspaces/ha-pp-reader`
+- Integration code: `custom_components/pp_reader/`
+- Frontend bundle: `custom_components/pp_reader/panel/`
+- Development scripts: `./scripts/setup_container`, `./scripts/develop`
+
+## Prerequisites
+1. Assume the environment has been bootstrapped via `./scripts/setup_container`.
+2. Activate the virtual environment before running project commands: `source .venv/bin/activate`.
+3. Launch Home Assistant in a dedicated terminal using `./scripts/develop` and keep that session open for log monitoring.
+4. Confirm the pp_reader panel is available at `http://127.0.0.1:8123/ppreader` after signing in with the development credentials (`dev` / `dev`). Make sure that all prerequisites, especially UI access, are in place before proceeding so you can confirm each DOM detail beyond doubt.
+
+## Task Approach
+### Preparation
+- Start a fresh browser session with developer tools (Elements + Console + Network) open.
+- Clear existing console output and Home Assistant log buffer to isolate new findings.
+
+### Structured DOM Survey
+1. Enumerate every top-level container, section, and widget rendered by the panel.
+2. For each element, capture:
+   - Tag name(s), key CSS classes/ids, and any data attributes that influence behaviour.
+   - Parent-child relationships up to the document root.
+   - Relative positioning (e.g., grid area, flex order) and layout dependencies.
+   - Dynamic states (expanded/collapsed variants, conditional rendering, lazy-loaded regions).
+   - Associated scripts, event listeners, or Home Assistant services/data stores that the element depends on.
+3. Trace how navigation, tabs, and interactive controls update or replace DOM nodes.
+4. Document how external resources (translations, REST endpoints, websockets) feed data into the DOM.
+5. Capture screenshots or DOM snapshots when they clarify complex nesting.
+
+### Validation Loop
+- Interact with each control (tabs, buttons, filters, sortable columns, dialogs, tooltips, scroll areas) to observe DOM mutations.
+- Resize the viewport and repeat critical interactions to verify responsive layout behaviour.
+- Monitor the Home Assistant terminal running `./scripts/develop` for warnings or errors mentioning `pp_reader`.
+- Keep the browser console visible and log any warnings, errors, or failed network requests.
+
+### Documentation Deliverable
+- Create a new document describing the DOM in a highly structured format suitable for future coding agents.
+- Organise the content with sections for global layout, each major region, and per-element subsections.
+- Include tables or bullet hierarchies that map element identifiers to their DOM paths and dependencies.
+- Highlight cross-component relationships, event propagation paths, and data flow.
+- Note any edge cases, conditional rendering triggers, or known limitations observed during inspection.
+
+## Completion Criteria
+- The DOM reference document fully explains structure, nesting, and dependencies for every dashboard element.
+- All interactions have been exercised at least once while monitoring logs and console output.
+- Any discovered issues or anomalies are documented with context and suggested follow-up actions.
+
+## Reporting Template
+Provide a final report containing:
+- **Summary**: High-level overview of inspected regions and documentation produced.
+- **DOM Reference Highlights**: Key structural insights, complex hierarchies, and dependency notes.
+- **Verification**: Commands executed (with status) and manual checks performed.
+- **Follow-ups**: Outstanding questions, potential improvements, or additional instrumentation recommended.


### PR DESCRIPTION
## Summary
- add a dedicated prompt for documenting the Portfolio Performance Reader panel DOM structure
- outline prerequisites, inspection steps, and reporting requirements for producing the DOM reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9f79f7bc833085b6eb1e35c7fb39