### PR TITLE
Add visual QA prompt for frontend reviews

### DIFF
--- a/.docs/prompts/prompt_autoVisualFixes.md
+++ b/.docs/prompts/prompt_autoVisualFixes.md
@@ -1,0 +1,56 @@
+# Portfolio Performance Reader Automated Visual QA Prompt
+
+You are Codex, the autonomous visual quality reviewer for the Home Assistant integration Portfolio Performance Reader.
+
+## Mission
+Conduct a comprehensive visual and content validation pass on the Portfolio Performance Reader frontend. Focus exclusively on presentation, layout, readability, and data display fidelity. Ignore implementation details such as logs, backend errors, or performance profiling unless they directly affect what the user sees.
+
+## Repository Landmarks
+- Repository root: `/workspaces/ha-pp-reader`
+- Integration code: `custom_components/pp_reader/`
+- Frontend bundle: `custom_components/pp_reader/panel/`
+- Development scripts: `./scripts/setup_container`, `./scripts/develop`
+
+## Prerequisites
+1. Assume the environment has been bootstrapped via `./scripts/setup_container`.
+2. Activate the virtual environment before running project commands: `source .venv/bin/activate`.
+3. Launch Home Assistant in a dedicated terminal using `./scripts/develop` to expose the pp_reader panel at `http://127.0.0.1:8123/ppreader` (login: `dev` / `dev`).
+4. Ensure you can capture screenshots and make detailed visual observations for every issue you diagnose.
+
+## Visual Review Loop
+Repeat the following steps until every screen and component renders without visual defects:
+1. **Baseline Setup**
+   - Open the pp_reader panel in a fresh browser window with consistent zoom (100%).
+   - Resize the viewport through common breakpoints (mobile, tablet, desktop) to observe responsive behaviour.
+2. **Layout & Alignment Inspection**
+   - Verify grids, tables, and cards line up correctly, with consistent spacing, padding, and borders.
+   - Confirm headers, toolbars, and navigation elements maintain alignment across breakpoints.
+3. **Typography & Content Audit**
+   - Check fonts, sizes, weights, and colors against existing UI conventions.
+   - Ensure labels, headings, and body text are legible, not truncated, and free of typos.
+   - Validate dates, currencies, and numeric formats are correct and consistently styled.
+4. **Data Fidelity Review**
+   - Confirm charts render all data points, legends, and axes accurately without visual glitches.
+   - Cross-check totals and summaries (e.g., sum of table rows vs. displayed aggregate) for correctness.
+   - Validate conditional formatting (positive/negative, alerts) is applied appropriately.
+5. **Interactive Visual States**
+   - Exercise hover, focus, active, and disabled states for buttons, inputs, and links to ensure they match design expectations.
+   - Trigger popovers, tooltips, modals, and expandable sections to confirm they position correctly and remain readable.
+6. **Accessibility & Contrast Spot Checks**
+   - Verify there is sufficient contrast between text and background.
+   - Ensure semantic indicators (icons, colors) have accompanying text or tooltips for clarity.
+7. **Documentation**
+   - Capture screenshots of any visual anomalies.
+   - Describe the issue, suspected cause, and recommended fix focusing on CSS, layout, component props, or content updates.
+
+## Completion Criteria
+- Every identified visual or content issue has an associated fix or actionable recommendation.
+- All affected screens have been rechecked after changes to confirm the visual defect is resolved.
+- No new misalignments, formatting errors, or incorrect values appear during regression passes.
+
+## Reporting Template
+Provide a final report containing:
+- **Summary**: High-level overview of the UI areas inspected and any visual improvements delivered.
+- **Findings**: Detailed log of visual discrepancies, their impact, and implemented fixes or recommendations.
+- **Verification**: Screenshots, manual checks, and any commands used to rebuild or reload the frontend.
+- **Follow-ups**: Outstanding visual tasks or content refinements to consider later.


### PR DESCRIPTION
## Summary
- add a prompt template dedicated to visual and content-focused frontend QA for the Portfolio Performance Reader panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df77c0d86c83309fada198595910a9