### PR TITLE
Improve PP reader mobile layout and fix footer copy

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -526,6 +526,38 @@ tbody tr:hover {
   }
 }
 
+@media (max-width: 600px) {
+  .expandable-portfolio-table th,
+  .expandable-portfolio-table td {
+    padding: 0.4rem 0.4rem;
+    font-size: 0.85rem;
+    line-height: 1.2;
+  }
+
+  .expandable-portfolio-table .portfolio-name {
+    font-size: 0.95rem;
+  }
+
+  .positions-container table th,
+  .positions-container table td {
+    padding: 0.35rem 0.3rem;
+    font-size: 0.7rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .expandable-portfolio-table th,
+  .expandable-portfolio-table td {
+    padding: 0.35rem 0.35rem;
+    font-size: 0.8rem;
+  }
+
+  .positions-container table th,
+  .positions-container table td {
+    font-size: 0.65rem;
+  }
+}
+
 /* === Sortierbare Tabellen (Änderung 9) ===
    Nutzt Klassen/Zustände die JS setzt:
    - th[data-sort-key] (generisch)

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
@@ -806,8 +806,8 @@ export function handleLastFileUpdate(update, root) {
   // Format abhängig vom Ort (Footer behält <strong>)
   if (el.closest('.footer-card')) {
     el.innerHTML = value
-      ? `📂 Letzte Aktualisierung Datei: <strong>${value}</strong>`
-      : `📂 Letzte Aktualisierung Datei: <strong>Unbekannt</strong>`;
+      ? `📂 Letzte Aktualisierung der Datei: <strong>${value}</strong>`
+      : `📂 Letzte Aktualisierung der Datei: <strong>Unbekannt</strong>`;
   } else {
     // Header/Meta-Version (schlichter Text)
     el.textContent = value

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
@@ -234,7 +234,7 @@ function buildExpandablePortfolioTable(depots) {
     { key: 'name', label: 'Name' },
     { key: 'position_count', label: 'Anzahl Positionen', align: 'right' },
     { key: 'current_value', label: 'Aktueller Wert', align: 'right' },
-    { key: 'gain_abs', label: 'gesamt +/-', align: 'right' },
+    { key: 'gain_abs', label: 'Gesamt +/-', align: 'right' },
     { key: 'gain_pct', label: '%', align: 'right' }
   ];
   cols.forEach(c => {
@@ -841,7 +841,7 @@ export async function renderDashboard(root, hass, panelConfig) {
     <div class="card footer-card">
       <div class="meta">
         <div class="last-file-update">
-          📂 Letzte Aktualisierung Datei: <strong>${lastFileUpdate || 'Unbekannt'}</strong>
+          📂 Letzte Aktualisierung der Datei: <strong>${lastFileUpdate || 'Unbekannt'}</strong>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- adjust the portfolio and positions tables for small screens to improve readability on phones
- capitalize the gain column header and update the footer copy to grammatically correct German
- align the live update wording with the initial render so both show the same footer text

## Testing
- Manual visual QA at http://127.0.0.1:8123/ppreader (desktop/tablet/mobile)


------
https://chatgpt.com/codex/tasks/task_e_68df91d6fc548330ae49c607cc7f127e