### PR TITLE
Fix Bestand column alignment in positions tables

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/data/updateConfigsWS.js
@@ -537,7 +537,7 @@ function renderPositionsTableInline(positions) {
     rows,
     [
       { key: 'name', label: 'Wertpapier' },
-      { key: 'current_holdings', label: 'Bestand' },
+      { key: 'current_holdings', label: 'Bestand', align: 'right' },
       { key: 'purchase_value', label: 'Kaufwert', align: 'right' },
       { key: 'current_value', label: 'Aktueller Wert', align: 'right' },
       { key: 'gain_abs', label: '+/-', align: 'right' },

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
@@ -117,7 +117,7 @@ function renderPositionsTable(positions) {
   // Mapping für makeTable
   const cols = [
     { key: 'name', label: 'Wertpapier' },
-    { key: 'current_holdings', label: 'Bestand' },
+    { key: 'current_holdings', label: 'Bestand', align: 'right' },
     { key: 'purchase_value', label: 'Kaufwert', align: 'right' },
     { key: 'current_value', label: 'Aktueller Wert', align: 'right' },
     { key: 'gain_abs', label: '+/-', align: 'right' },


### PR DESCRIPTION
## Summary
- right-align the "Bestand" column in the positions table so numeric holdings line up visually
- mirror the alignment change in the websocket update renderer to keep live refreshes consistent

## Testing
- Manual QA (Home Assistant dev server)

------
https://chatgpt.com/codex/tasks/task_e_68dfb54b5dd88330a633cfa071506c0f