### PR TITLE
Handle missing FX conversions in dashboard

### DIFF
--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -1139,14 +1139,16 @@ class _SyncRunner:
         for account in db_accounts:
             currency = account["currency_code"]
             orig_balance = account["raw_balance"] / 100.0
+            fx_unavailable = False
             if currency != "EUR":
                 rate = fx_rates.get(currency)
                 if rate:
                     eur_balance = orig_balance / rate
                 else:
-                    eur_balance = 0.0
+                    eur_balance = None
+                    fx_unavailable = True
                     _LOGGER.warning(
-                        "FX: Kein Kurs für %s - setze EUR-Wert=0",
+                        "FX: Kein Kurs für %s – EUR-Wert nicht verfügbar",
                         currency,
                     )
             else:
@@ -1157,7 +1159,8 @@ class _SyncRunner:
                     "name": account["name"],
                     "currency_code": currency,
                     "orig_balance": round(orig_balance, 2),
-                    "balance": round(eur_balance, 2),
+                    "balance": round(eur_balance, 2) if eur_balance is not None else None,
+                    "fx_unavailable": fx_unavailable,
                 }
             )
 

--- a/custom_components/pp_reader/data/websocket.py
+++ b/custom_components/pp_reader/data/websocket.py
@@ -84,13 +84,18 @@ async def _load_accounts_payload(
 
         currency = getattr(account, "currency_code", "EUR") or "EUR"
         orig_balance = account.balance / 100.0
+        fx_unavailable = False
         if currency != "EUR":
             rate = fx_rates.get(currency)
             if rate:
                 eur_balance = orig_balance / rate
             else:
-                eur_balance = 0.0
-                _LOGGER.warning("FX: Kein Kurs für %s - setze EUR-Wert=0", currency)
+                eur_balance = None
+                fx_unavailable = True
+                _LOGGER.warning(
+                    "FX: Kein Kurs für %s – EUR-Wert nicht verfügbar",
+                    currency,
+                )
         else:
             eur_balance = orig_balance
 
@@ -99,7 +104,8 @@ async def _load_accounts_payload(
                 "name": account.name,
                 "currency_code": currency,
                 "orig_balance": round(orig_balance, 2),
-                "balance": round(eur_balance, 2),
+                "balance": round(eur_balance, 2) if eur_balance is not None else None,
+                "fx_unavailable": fx_unavailable,
             }
         )
 

--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -165,6 +165,24 @@ table {
   margin: 0;
 }
 
+.missing-value {
+  color: var(--secondary-text-color);
+  font-style: italic;
+}
+
+.table-note {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--secondary-text-color);
+}
+
+.table-note__icon {
+  line-height: 1.3;
+}
+
 th,
 td {
   padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary
- stop treating missing FX conversions as zero-valued EUR balances in account payloads
- surface the FX availability flag in the frontend and render a warning plus placeholders instead of misleading zeroes
- style missing values and update total calculations so aggregates skip unknown FX data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb54b5dd88330a633cfa071506c0f