### PR TITLE
Add warning when FX rates are unavailable in dashboard

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -157,6 +157,13 @@
   /* HA-Variable für hervorgehobenen Text */
 }
 
+.fx-rate-warning {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--warning-color, #f0ad4e);
+  line-height: 1.4;
+}
+
 table {
   width: auto;
   min-width: 100%;


### PR DESCRIPTION
## Summary
- flag foreign currency balances that fall back to 0 € when the FX rate is missing and surface a warning in the dashboard
- keep websocket account updates in sync so the warning appears/disappears in real time
- add styling for the inline warning message to match the card layout

## Testing
- Manual UI verification in Home Assistant dev environment

------
https://chatgpt.com/codex/tasks/task_e_68dfb54b5dd88330a633cfa071506c0f