### PR TITLE
Fix security detail header metadata layout

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -122,6 +122,45 @@
   transition: max-height 0.3s ease, opacity 0.3s ease;
 }
 
+.security-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin: 0.75rem 0 1.25rem;
+  width: 100%;
+}
+
+.security-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.security-meta-item .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--secondary-text-color);
+}
+
+.security-meta-item .value {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--primary-text-color);
+}
+
+@media (max-width: 600px) {
+  .security-meta-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem 1rem;
+  }
+
+  .security-meta-item {
+    align-items: flex-start;
+  }
+}
+
 /* Footer card kann separat bleiben */
 .footer-card {
   display: flex;


### PR DESCRIPTION
## Summary
- style the security detail header metadata with a responsive grid
- emphasize labels and values to improve readability on desktop and mobile views

## Testing
- Manual verification of the security detail view in the Home Assistant panel

------
https://chatgpt.com/codex/tasks/task_e_68dfc7c2bcdc8330b8e0619e7151bb24