### PR TITLE
Fix FX currency table footer placeholders

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/content/elements.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/content/elements.js
@@ -146,13 +146,21 @@ export function makeTable(rows, cols, sumColumns = [], options = {}) {
     const alignClass = c.align === 'right' ? ' class="align-right"' : '';
     if (idx === 0) {
       html += `<td${alignClass}>Summe</td>`;
-    } else if (sums[c.key] != null) {
-      html += `<td${alignClass}>${formatValue(c.key, sums[c.key], undefined, sumMeta[c.key])}</td>`;
-    } else if (c.key === 'gain_pct' && sums['gain_pct'] != null) {
-      html += `<td${alignClass}>${formatValue('gain_pct', sums['gain_pct'], undefined, sumMeta[c.key])}</td>`;
-    } else {
-      html += '<td></td>';
+      return;
     }
+
+    if (sums[c.key] != null) {
+      html += `<td${alignClass}>${formatValue(c.key, sums[c.key], undefined, sumMeta[c.key])}</td>`;
+      return;
+    }
+
+    if (c.key === 'gain_pct' && sums['gain_pct'] != null) {
+      html += `<td${alignClass}>${formatValue('gain_pct', sums['gain_pct'], undefined, sumMeta[c.key])}</td>`;
+      return;
+    }
+
+    const fallbackContext = sumMeta[c.key] ?? { hasValue: false };
+    html += `<td${alignClass}>${formatValue(c.key, null, undefined, fallbackContext)}</td>`;
   });
   html += '</tr>';
 


### PR DESCRIPTION
## Summary
- show a placeholder in portfolio dashboard table footers when a summed value is unavailable

## Testing
- Manual UI check at http://127.0.0.1:8123/ppreader

------
https://chatgpt.com/codex/tasks/task_e_68dfc7c2bcdc8330b8e0619e7151bb24