### PR TITLE
Fix portfolio dashboard column header wrapping on large screens

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -228,6 +228,16 @@ td {
   font-size: 1.25rem;
 }
 
+.card table th {
+  white-space: nowrap;
+}
+
+@media (max-width: 800px) {
+  .card table th {
+    white-space: normal;
+  }
+}
+
 th {
   background: var(--primary-background-color, #fafafa);
   font-weight: 600;


### PR DESCRIPTION
## Summary
- prevent dashboard table headers from wrapping on wide viewports so the primary columns stay readable
- re-enable wrapping below 800px to preserve the mobile layout

## Testing
- not run (visual change)


------
https://chatgpt.com/codex/tasks/task_e_68dfda07acfc8330b5aadf3e9db0943b