### PR TITLE
Fix sticky header overlapping section titles

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/base.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/base.css
@@ -6,6 +6,7 @@
   box-sizing: border-box;
   overflow: hidden;
   --pp-reader-flash-color: rgba(3, 169, 244, 0.22);
+  --pp-reader-sticky-offset: 0px;
 }
 
 /* Panel-Root */

--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -16,7 +16,7 @@
 
 .card h2 {
   position: sticky;
-  top: 0;
+  top: var(--pp-reader-sticky-offset, 0px);
   z-index: 2;
   font-size: 1.35rem;
   padding-top: 0.5rem;
@@ -232,7 +232,7 @@ th {
   background: var(--primary-background-color, #fafafa);
   font-weight: 600;
   position: sticky;
-  top: 0;
+  top: var(--pp-reader-sticky-offset, 0px);
   z-index: 1;
   text-align: left;
 }

--- a/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
@@ -27,6 +27,9 @@ class PPReaderPanel extends HTMLElement {
     this._loadCss('css/nav.css');
     this.shadowRoot.appendChild(container);
 
+    this._headerObserver = null;
+    this._headerMutationObserver = null;
+
     // NEU: Referenz auf das Dashboard-Element sichern
     this._dashboardEl = container.querySelector('pp-reader-dashboard');
     if (!this._dashboardEl) {
@@ -41,6 +44,8 @@ class PPReaderPanel extends HTMLElement {
       } catch (error) {
         console.warn('[pp_reader] Konnte Dashboard-Referenz nicht registrieren', error);
       }
+
+      this._initializeHeaderOffsetTracking();
     }
 
     try {
@@ -144,6 +149,14 @@ class PPReaderPanel extends HTMLElement {
     if (this._resizeObserver) {
       this._resizeObserver.disconnect();
     }
+    if (this._headerObserver) {
+      this._headerObserver.disconnect();
+      this._headerObserver = null;
+    }
+    if (this._headerMutationObserver) {
+      this._headerMutationObserver.disconnect();
+      this._headerMutationObserver = null;
+    }
     if (window.__ppReaderPanelHosts instanceof Set) {
       window.__ppReaderPanelHosts.delete(this);
     }
@@ -152,6 +165,60 @@ class PPReaderPanel extends HTMLElement {
     }
   }
 }
+
+PPReaderPanel.prototype._initializeHeaderOffsetTracking = function _initializeHeaderOffsetTracking() {
+  if (!this._dashboardEl) {
+    return;
+  }
+
+  const attachObserver = (headerCard) => {
+    if (!headerCard) {
+      return false;
+    }
+
+    if (this._headerObserver) {
+      this._headerObserver.disconnect();
+    }
+
+    const updateOffset = (height) => {
+      this.style.setProperty('--pp-reader-sticky-offset', `${Math.ceil(height)}px`);
+    };
+
+    updateOffset(headerCard.getBoundingClientRect().height);
+
+    this._headerObserver = new ResizeObserver((entries) => {
+      const entry = entries && entries[0];
+      if (!entry) {
+        return;
+      }
+      updateOffset(entry.contentRect.height);
+    });
+    this._headerObserver.observe(headerCard);
+    return true;
+  };
+
+  const tryAttach = () => attachObserver(this._dashboardEl.querySelector('.header-card'));
+
+  if (tryAttach()) {
+    return;
+  }
+
+  if (this._headerMutationObserver) {
+    this._headerMutationObserver.disconnect();
+  }
+
+  this._headerMutationObserver = new MutationObserver(() => {
+    if (tryAttach() && this._headerMutationObserver) {
+      this._headerMutationObserver.disconnect();
+      this._headerMutationObserver = null;
+    }
+  });
+
+  this._headerMutationObserver.observe(this._dashboardEl, {
+    childList: true,
+    subtree: true,
+  });
+};
 
 // Custom Element registrieren
 if (!customElements.get('pp-reader-panel')) {


### PR DESCRIPTION
## Summary
- expose the sticky header height as a CSS variable on the panel host
- update card and table sticky positions to respect the header offset so section titles stay visible
- observe header size changes to keep the offset in sync when the header collapses

## Testing
- manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68dfda07acfc8330b5aadf3e9db0943b