### PR TITLE
Fix footer selection in portfolio overview

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/tabs/overview.js
@@ -501,7 +501,9 @@ export function updatePortfolioFooterFromDom(target) {
 
   const sumGainPct = sumHasValue && sumPurchase > 0 ? (sumGainAbs / sumPurchase) * 100 : null;
 
-  let footer = tbody.querySelector('tr.footer-row');
+  let footer = Array.from(tbody.children).find((child) =>
+    child instanceof HTMLTableRowElement && child.classList.contains('footer-row')
+  );
   if (!footer) {
     footer = document.createElement('tr');
     footer.classList.add('footer-row');


### PR DESCRIPTION
## Summary
- ensure the portfolio overview footer update targets only the table footer row
- prevent nested position table sums from being replaced when recomputing totals

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0ab32ce648330b1996191cd080210