### PR TITLE
Fix cursor style for portfolio position rows

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -684,6 +684,11 @@ tbody tr:hover {
   font-size: 0.85rem;
 }
 
+.positions-container table tr.position-row,
+.positions-container table tr.position-row td {
+  cursor: pointer;
+}
+
 /* Kleinere Screens: etwas kompakter */
 @media (max-width: 800px) {
 


### PR DESCRIPTION
## Summary
- set a pointer cursor on expanded portfolio position rows so they behave like interactive links

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0ab94b2e08330aff5328c4d401751