### PR TITLE
Include native security price in snapshot payload

### DIFF
--- a/tests/test_db_access.py
+++ b/tests/test_db_access.py
@@ -155,9 +155,14 @@ pp_reader_pkg = types.ModuleType("custom_components.pp_reader")
 pp_reader_pkg.__path__ = [str(REPO_ROOT / "custom_components" / "pp_reader")]
 sys.modules.setdefault("custom_components.pp_reader", pp_reader_pkg)
 
+# Ensure hierarchical attributes exist so monkeypatch resolution works when
+# submodules have not been imported yet.
+setattr(custom_components_pkg, "pp_reader", pp_reader_pkg)
+
 data_pkg = types.ModuleType("custom_components.pp_reader.data")
 data_pkg.__path__ = [str(REPO_ROOT / "custom_components" / "pp_reader" / "data")]
 sys.modules.setdefault("custom_components.pp_reader.data", data_pkg)
+setattr(pp_reader_pkg, "data", data_pkg)
 
 
 from custom_components.pp_reader.data.db_access import (
@@ -361,6 +366,7 @@ def test_get_security_snapshot_multicurrency(
     assert snapshot["name"] == "US Tech"
     assert snapshot["currency_code"] == "USD"
     assert snapshot["total_holdings"] == pytest.approx(3.75, rel=0, abs=1e-6)
+    assert snapshot["last_price_native"] == pytest.approx(200.0, rel=0, abs=1e-4)
     assert snapshot["last_price_eur"] == pytest.approx(160.0, rel=0, abs=1e-4)
     assert snapshot["market_value_eur"] == pytest.approx(600.0, rel=0, abs=1e-2)
 

--- a/tests/test_ws_security_history.py
+++ b/tests/test_ws_security_history.py
@@ -432,6 +432,7 @@ def test_ws_get_security_snapshot_success(seeded_history_db: Path) -> None:
         "name": "Acme Corp",
         "currency_code": "EUR",
         "total_holdings": 3.5,
+        "last_price_native": 12.5,
         "last_price_eur": 12.5,
         "market_value_eur": 43.75,
     }


### PR DESCRIPTION
## Summary
- add the native last price to the security snapshot payload so the frontend can render the correct currency value
- update the snapshot websocket fixture and tests to cover the new field
- expose stub module attributes in the db access tests to keep monkeypatch resolution working

## Testing
- pytest tests/test_db_access.py::test_get_security_snapshot_multicurrency tests/test_ws_security_history.py::test_ws_get_security_snapshot_success

------
https://chatgpt.com/codex/tasks/task_e_68e0ac41665c83309834ec786960fc0b