### PR TITLE
Fix security detail price history chart rendering

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -510,9 +510,21 @@ tbody tr:hover {
   background: rgba(244, 67, 54, 0.12);
 }
 
+
 .history-placeholder[data-state='loaded'] {
   color: var(--primary-text-color);
   background: rgba(63, 81, 181, 0.08);
+}
+
+.history-chart {
+  position: relative;
+  width: 100%;
+  min-height: 220px;
+  display: block;
+}
+
+.history-chart .line-chart-container {
+  width: 100%;
 }
 
 .line-chart-container {


### PR DESCRIPTION
## Summary
- normalise history dates before charting so the X axis interprets API values correctly
- replace the placeholder message with a rendered line chart and reuse data on range changes
- add styling for the chart host and show the correct currency in the chart tooltip

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0b21a2df48330be4a2f936f6dfc1f