### PR TITLE
Fix security history chart axes display

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -540,6 +540,34 @@ tbody tr:hover {
   display: block;
 }
 
+.line-chart-axis {
+  font-size: 0.75rem;
+  color: var(--secondary-text-color);
+  pointer-events: none;
+}
+
+.line-chart-axis-x {
+  height: 20px;
+}
+
+.line-chart-axis-y {
+  text-align: right;
+}
+
+.line-chart-axis-tick {
+  white-space: nowrap;
+  color: inherit;
+}
+
+.line-chart-axis-tick-y {
+  transform: translateY(50%);
+  padding-right: 0.35rem;
+}
+
+.line-chart-axis-tick-x {
+  bottom: 0;
+}
+
 .line-chart-path {
   stroke: var(--pp-reader-chart-line, #3f51b5);
 }


### PR DESCRIPTION
## Summary
- add adaptive axis rendering for the security history line chart
- style the chart container to show tick labels on both axes

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0b8acac188330b3df1109066e2ec9