### PR TITLE
Fix security detail chart scroll and tooltip positioning

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -496,6 +496,15 @@ tbody tr:hover {
   gap: 0.75rem;
 }
 
+.card.security-detail-placeholder {
+  overflow: visible;
+}
+
+.card.security-detail-placeholder > h2 {
+  position: static;
+  top: auto;
+}
+
 .history-placeholder {
   padding: 1.25rem;
   border-radius: 0.5rem;

--- a/custom_components/pp_reader/www/pp_reader_dashboard/js/content/charting.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/js/content/charting.js
@@ -260,7 +260,7 @@ function formatTooltip(state, point) {
   });
 }
 
-function updateTooltipPosition(state, point) {
+function updateTooltipPosition(state, point, pointerY) {
   const { tooltip, width, margin } = state;
   if (!tooltip) {
     return;
@@ -274,9 +274,12 @@ function updateTooltipPosition(state, point) {
   const horizontal = clamp(point.x - tooltipWidth / 2, margin.left, width - margin.right - tooltipWidth);
   const maxVertical = Math.max(baselineY - tooltipHeight, 0);
   const padding = 12;
-  let vertical = point.y + padding;
+  const anchorY = Number.isFinite(pointerY)
+    ? clamp(pointerY, margin.top, baselineY)
+    : point.y;
+  let vertical = anchorY + padding;
   if (vertical > maxVertical) {
-    vertical = point.y - tooltipHeight - padding;
+    vertical = anchorY - tooltipHeight - padding;
   }
   vertical = clamp(vertical, 0, maxVertical);
   tooltip.style.transform = `translate(${Math.round(horizontal)}px, ${Math.round(vertical)}px)`;
@@ -309,6 +312,7 @@ function attachPointerHandlers(container, state) {
 
     const rect = state.svg.getBoundingClientRect();
     const pointerX = event.clientX - rect.left;
+    const pointerY = event.clientY - rect.top;
     let closest = state.points[0];
     let minDistance = Math.abs(pointerX - closest.x);
 
@@ -345,7 +349,7 @@ function attachPointerHandlers(container, state) {
 
     if (state.tooltip) {
       state.tooltip.innerHTML = formatTooltip(state, closest);
-      updateTooltipPosition(state, closest);
+      updateTooltipPosition(state, closest, pointerY);
     }
   };
 


### PR DESCRIPTION
## Summary
- prevent the security detail history card from scrolling independently so the panel scrolls instead
- align the history chart tooltip with the pointer position while respecting chart bounds

## Testing
- `./scripts/lint` *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c231fe548330b2aa464cd2f69848