### PR TITLE
Add TypeScript toolchain scripts and dev dependencies

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -1,5 +1,5 @@
 1. Toolchain bootstrap
-   a) [ ] Extend Node dependencies and scripts for TypeScript workflow
+   a) [x] Extend Node dependencies and scripts for TypeScript workflow
       - Datei: `package.json`
       - Abschnitt: `dependencies`, `devDependencies`, `scripts`
       - Ziel: Füge TypeScript, Vite/Rollup, ESLint (TS Plugin) hinzu und richte `npm run build`, `npm run dev`, `npm run typecheck`, `npm run lint:ts` ein.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "tests"
   },
   "scripts": {
+    "build": "vite build",
+    "dev": "vite dev",
+    "typecheck": "tsc --noEmit",
+    "lint:ts": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -15,5 +19,13 @@
   "type": "module",
   "dependencies": {
     "jsdom": "^27.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.5.0",
+    "eslint-config-prettier": "^9.1.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add TypeScript, Vite, and ESLint dev dependencies to package.json to support the upcoming TypeScript migration
- add npm scripts for build, dev, type checking, and linting
- mark the checklist item for the package.json update as complete

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e0d13c072c8330afe75193b33bcac9