### PR TITLE
Lock Node.js engine requirements for TS build

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -3,7 +3,7 @@
       - Datei: `package.json`
       - Abschnitt: `dependencies`, `devDependencies`, `scripts`
       - Ziel: Füge TypeScript, Vite/Rollup, ESLint (TS Plugin) hinzu und richte `npm run build`, `npm run dev`, `npm run typecheck`, `npm run lint:ts` ein.
-   b) [ ] Sperre Node-Version und Projekt-Metadaten für den neuen Build
+   b) [x] Sperre Node-Version und Projekt-Metadaten für den neuen Build
       - Datei: `package.json`
       - Abschnitt: `engines`, Projektbeschreibung
       - Ziel: Stelle sicher, dass die erforderliche Node-Version und Hinweise zur TypeScript-Buildpipeline dokumentiert sind.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ha-pp-reader",
   "version": "1.0.0",
-  "description": "Portfolio Performance Reader brings your local Portfolio Performance (`.portfolio`) file into Home Assistant with live prices, consolidated sensors, and a purpose-built dashboard panel. The integration parses your portfolios on the server, keeps a dedicated SQLite database in sync, and surfaces aggregated values to both the UI and automations.【F:ARCHITECTURE.md†L29-L44】",
+  "description": "Portfolio Performance Reader brings your local Portfolio Performance (`.portfolio`) file into Home Assistant with live prices, consolidated sensors, and a purpose-built dashboard panel. The integration parses your portfolios on the server, keeps a dedicated SQLite database in sync, and surfaces aggregated values to both the UI and automations. A TypeScript/Vite build pipeline delivers the dashboard assets.",
   "main": "index.js",
   "directories": {
     "test": "tests"
@@ -27,5 +27,9 @@
     "eslint-config-prettier": "^9.1.0",
     "typescript": "^5.4.0",
     "vite": "^5.2.0"
+  },
+  "engines": {
+    "node": "^18.18.0 || >=20.0.0",
+    "npm": ">=10.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- update the package description to note the TypeScript/Vite build pipeline
- enforce minimum Node.js and npm versions via the package.json engines field
- mark the Node engine checklist item as complete in TODO_frontend_ts_migration.md

## Testing
- not run (not required for metadata updates)


------
https://chatgpt.com/codex/tasks/task_e_68e0d3f540448330b4d833780b14ca0c