### PR TITLE
Add TypeScript compiler configuration

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -7,7 +7,7 @@
       - Datei: `package.json`
       - Abschnitt: `engines`, Projektbeschreibung
       - Ziel: Stelle sicher, dass die erforderliche Node-Version und Hinweise zur TypeScript-Buildpipeline dokumentiert sind.
-   c) [ ] Lege TypeScript-Konfiguration an
+   c) [x] Lege TypeScript-Konfiguration an
       - Datei: `tsconfig.json` (neu)
       - Abschnitt: Compileroptionen
       - Ziel: Aktiviere Strict-Modus, ESM-Ausgabe, Source-Maps und passende Pfade für bundlergesteuerte Ausgabe.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "rootDir": "src",
+    "outDir": "custom_components/pp_reader/www/pp_reader_dashboard/js",
+    "baseUrl": ".",
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "useDefineForClassFields": true,
+    "sourceMap": true,
+    "inlineSources": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "custom_components/pp_reader/www/pp_reader_dashboard/js"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a strict TypeScript compiler configuration aligned with the upcoming Vite toolchain
- mark the TypeScript configuration task as completed in the migration checklist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d7bffd7c8330824f9c7533db1a73