### PR TITLE
Add Vite configuration for dashboard build

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -11,7 +11,7 @@
       - Datei: `tsconfig.json` (neu)
       - Abschnitt: Compileroptionen
       - Ziel: Aktiviere Strict-Modus, ESM-Ausgabe, Source-Maps und passende Pfade für bundlergesteuerte Ausgabe.
-   d) [ ] Richte Vite/Rollup Konfiguration ein
+   d) [x] Richte Vite/Rollup Konfiguration ein
       - Datei: `vite.config.mjs` (neu)
       - Abschnitt: Exportierte Config
       - Ziel: Definiere Entry `src/dashboard.ts`, Ausgabepfad `custom_components/pp_reader/www/pp_reader_dashboard/js/`, Cache-Busting Hash und Source-Map-Generierung.

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,35 @@
+/**
+ * Vite configuration for the PP Reader dashboard TypeScript build pipeline.
+ *
+ * The configuration keeps the existing Home Assistant asset layout by emitting
+ * bundled files directly into `custom_components/pp_reader/www/pp_reader_dashboard/js/`
+ * while enabling cache busting through hashed filenames and source map output
+ * for easier debugging.
+ */
+import { defineConfig } from 'vite';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = dirname(fileURLToPath(import.meta.url));
+const entryFile = resolve(projectRoot, 'src/dashboard.ts');
+const outputDirectory = resolve(
+  projectRoot,
+  'custom_components/pp_reader/www/pp_reader_dashboard/js',
+);
+
+export default defineConfig({
+  publicDir: false,
+  build: {
+    sourcemap: true,
+    emptyOutDir: false,
+    outDir: outputDirectory,
+    rollupOptions: {
+      input: entryFile,
+      output: {
+        entryFileNames: 'dashboard.[hash].js',
+        chunkFileNames: 'chunks/[name].[hash].js',
+        assetFileNames: 'assets/[name].[hash][extname]',
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite configuration that targets the dashboard TypeScript entry point
- configure hashed output filenames, source maps, and the Home Assistant asset directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d957280c83308e2f109be385aca7