### PR TITLE
Add ESLint configuration for TypeScript sources

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -15,7 +15,7 @@
       - Datei: `vite.config.mjs` (neu)
       - Abschnitt: Exportierte Config
       - Ziel: Definiere Entry `src/dashboard.ts`, Ausgabepfad `custom_components/pp_reader/www/pp_reader_dashboard/js/`, Cache-Busting Hash und Source-Map-Generierung.
-   e) [ ] Ergänze ESLint-Konfiguration für TypeScript
+   e) [x] Ergänze ESLint-Konfiguration für TypeScript
       - Datei: `.eslintrc.cjs` (neu oder aktualisiert)
       - Abschnitt: Parser, Plugins, Overrides für TypeScript
       - Ziel: Linting-Regeln für das neue TypeScript-Quellverzeichnis bereitstellen.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,44 @@
+/**
+ * ESLint configuration for Portfolio Performance Reader frontend TypeScript sources.
+ * Configures the TypeScript parser and rule presets to lint the new src/ tree.
+ */
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: ["./tsconfig.json"],
+    tsconfigRootDir: __dirname,
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:@typescript-eslint/stylistic",
+    "plugin:@typescript-eslint/strict",
+    "prettier",
+  ],
+  ignorePatterns: ["custom_components/", "dist/", "node_modules/"],
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      rules: {
+        "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports" }],
+        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/no-misused-promises": [
+          "error",
+          {
+            checksVoidReturn: {
+              attributes: false,
+            },
+          },
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a dedicated ESLint configuration that enables the TypeScript parser and presets
- configure stylistic and safety rules for upcoming src/ tree
- ignore generated Home Assistant assets while linting

## Testing
- npm run lint:ts *(fails: src/**/*.{ts,tsx} not found yet)*

------
https://chatgpt.com/codex/tasks/task_e_68e0dbfa33b883309d71965a1a22b7d8