### PR TITLE
Add TypeScript source tree mirroring legacy dashboard modules

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -21,7 +21,7 @@
       - Ziel: Linting-Regeln für das neue TypeScript-Quellverzeichnis bereitstellen.
 
 2. TypeScript-Quellstruktur anlegen
-   a) [ ] Erstelle `src/` Verzeichnis spiegelnd zum bisherigen `js/`
+   a) [x] Erstelle `src/` Verzeichnis spiegelnd zum bisherigen `js/`
       - Datei: `src/` (neu, Struktur nach `custom_components/pp_reader/www/pp_reader_dashboard/js/`)
       - Abschnitt: Alle Module (`dashboard`, `data`, `interaction`, `content` etc.)
       - Ziel: Kopiere bestehende Logik unverändert als `.ts` Dateien, um später schrittweise zu typisieren.

--- a/src/content/charting.ts
+++ b/src/content/charting.ts
@@ -1,0 +1,827 @@
+// @ts-nocheck
+
+/**
+ * Chart preparation utilities preserved from the legacy dashboard.
+ */
+
+/**
+ * Lightweight SVG chart helpers for the PP Reader dashboard.
+ *
+ * Provides rendering logic for historical security price charts without
+ * introducing external dependencies. The helpers expose a simple API with
+ * `renderLineChart` for initial setup and `updateLineChart` to mutate an
+ * existing chart instance.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const DEFAULT_WIDTH = 640;
+const DEFAULT_HEIGHT = 260;
+const DEFAULT_MARGIN = { top: 12, right: 16, bottom: 24, left: 16 };
+const DEFAULT_COLOR = 'var(--pp-reader-chart-line, #3f51b5)';
+const DEFAULT_AREA = 'var(--pp-reader-chart-area, rgba(63, 81, 181, 0.12))';
+const DEFAULT_TICK_FONT = '0.75rem';
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function createSvgElement(tag, attrs = {}) {
+  const element = document.createElementNS(SVG_NS, tag);
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (value == null) {
+      return;
+    }
+    element.setAttribute(key, String(value));
+  });
+  return element;
+}
+
+function toNumber(value, fallback = null) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+}
+
+function toTimestamp(value, index) {
+  if (value instanceof Date) {
+    const timestamp = value.getTime();
+    return Number.isFinite(timestamp) ? timestamp : index;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return index;
+}
+
+function defaultXFormatter(timestamp, dataPoint) {
+  if (Number.isFinite(timestamp)) {
+    const date = new Date(timestamp);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleDateString('de-DE');
+    }
+  }
+
+  if (dataPoint?.date) {
+    return String(dataPoint.date);
+  }
+
+  if (timestamp == null) {
+    return '';
+  }
+
+  return String(timestamp);
+}
+
+function defaultYFormatter(value) {
+  const numeric = Number.isFinite(value) ? value : Number.parseFloat(value) || 0;
+  return numeric.toLocaleString('de-DE', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function defaultTooltipRenderer({ xFormatted, yFormatted }) {
+  return `
+    <div class="chart-tooltip-date">${xFormatted}</div>
+    <div class="chart-tooltip-value">${yFormatted}&nbsp;€</div>
+  `;
+}
+
+function ensureChartState(container) {
+  if (!container.__chartState) {
+    container.__chartState = {};
+  }
+  return container.__chartState;
+}
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+function buildAreaPath(points, baselineY) {
+  if (!Array.isArray(points) || points.length === 0) {
+    return '';
+  }
+
+  const moveLine = points
+    .map((point, index) => {
+      const command = index === 0 ? 'M' : 'L';
+      return `${command}${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  const closing = `L${points[points.length - 1].x.toFixed(2)} ${baselineY.toFixed(
+    2,
+  )} L${points[0].x.toFixed(2)} ${baselineY.toFixed(2)} Z`;
+
+  return `${moveLine} ${closing}`;
+}
+
+function buildLinePath(points) {
+  if (!Array.isArray(points) || points.length === 0) {
+    return '';
+  }
+
+  return points
+    .map((point, index) => {
+      const command = index === 0 ? 'M' : 'L';
+      return `${command}${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
+    })
+    .join(' ');
+}
+
+function computePoints(series, dimensions, accessors) {
+  const { width, height, margin } = dimensions;
+  const { xAccessor, yAccessor } = accessors;
+
+  if (!Array.isArray(series) || series.length === 0) {
+    return { points: [], range: null };
+  }
+
+  const rawPoints = series
+    .map((entry, index) => {
+      const rawX = xAccessor(entry, index);
+      const rawY = yAccessor(entry, index);
+      const xValue = toTimestamp(rawX, index);
+      const yValue = toNumber(rawY);
+      if (!Number.isFinite(yValue)) {
+        return null;
+      }
+      return {
+        index,
+        data: entry,
+        xValue,
+        yValue,
+      };
+    })
+    .filter(Boolean);
+
+  if (rawPoints.length === 0) {
+    return { points: [], range: null };
+  }
+
+  const minX = rawPoints.reduce((min, point) => Math.min(min, point.xValue), rawPoints[0].xValue);
+  const maxX = rawPoints.reduce((max, point) => Math.max(max, point.xValue), rawPoints[0].xValue);
+  const minY = rawPoints.reduce((min, point) => Math.min(min, point.yValue), rawPoints[0].yValue);
+  const maxY = rawPoints.reduce((max, point) => Math.max(max, point.yValue), rawPoints[0].yValue);
+
+  const boundedWidth = Math.max(width - margin.left - margin.right, 1);
+  const boundedHeight = Math.max(height - margin.top - margin.bottom, 1);
+
+  const safeMinX = Number.isFinite(minX) ? minX : 0;
+  const safeMaxX = Number.isFinite(maxX) ? maxX : safeMinX + 1;
+  const safeMinY = Number.isFinite(minY) ? minY : 0;
+  const safeMaxY = Number.isFinite(maxY) ? maxY : safeMinY + 1;
+
+  const desiredYTicks = Math.max(
+    2,
+    Math.min(
+      6,
+      Math.round(
+        Math.max(height - margin.top - margin.bottom, 0) / 60,
+      ) || 4,
+    ),
+  );
+  const { niceMin: domainMinY, niceMax: domainMaxY } = computeNiceDomain(
+    safeMinY,
+    safeMaxY,
+    desiredYTicks,
+  );
+
+  const effectiveMinY = Number.isFinite(domainMinY) ? domainMinY : safeMinY;
+  const effectiveMaxY = Number.isFinite(domainMaxY) ? domainMaxY : safeMaxY;
+
+  const rangeX = safeMaxX - safeMinX || 1;
+  const rangeY = effectiveMaxY - effectiveMinY || 1;
+
+  const points = rawPoints.map((point) => {
+    const ratioX = rangeX === 0 ? 0.5 : (point.xValue - safeMinX) / rangeX;
+    const ratioY = rangeY === 0 ? 0.5 : (point.yValue - effectiveMinY) / rangeY;
+    const x = margin.left + ratioX * boundedWidth;
+    const y = margin.top + (1 - ratioY) * boundedHeight;
+    return {
+      ...point,
+      x,
+      y,
+    };
+  });
+
+  return {
+    points,
+    range: {
+      minX: safeMinX,
+      maxX: safeMaxX,
+      minY: effectiveMinY,
+      maxY: effectiveMaxY,
+      boundedWidth,
+      boundedHeight,
+    },
+  };
+}
+
+function assignDimensions(state, width, height, margin) {
+  state.width = Number.isFinite(width) ? width : DEFAULT_WIDTH;
+  state.height = Number.isFinite(height) ? height : DEFAULT_HEIGHT;
+  state.margin = {
+    top: Number.isFinite(margin?.top) ? margin.top : DEFAULT_MARGIN.top,
+    right: Number.isFinite(margin?.right) ? margin.right : DEFAULT_MARGIN.right,
+    bottom: Number.isFinite(margin?.bottom) ? margin.bottom : DEFAULT_MARGIN.bottom,
+    left: Number.isFinite(margin?.left) ? margin.left : DEFAULT_MARGIN.left,
+  };
+}
+
+function formatTooltip(state, point) {
+  const xFormatted = state.xFormatter(point.xValue, point.data, point.index);
+  const yFormatted = state.yFormatter(point.yValue, point.data, point.index);
+  return state.tooltipRenderer({
+    point,
+    xFormatted,
+    yFormatted,
+    data: point.data,
+    index: point.index,
+  });
+}
+
+function updateTooltipPosition(state, point, pointerY) {
+  const { tooltip, width, margin } = state;
+  if (!tooltip) {
+    return;
+  }
+
+  const baselineY = state.height - margin.bottom;
+  tooltip.style.visibility = 'visible';
+  tooltip.style.opacity = '1';
+  const tooltipWidth = tooltip.offsetWidth || 0;
+  const tooltipHeight = tooltip.offsetHeight || 0;
+  const horizontal = clamp(point.x - tooltipWidth / 2, margin.left, width - margin.right - tooltipWidth);
+  const maxVertical = Math.max(baselineY - tooltipHeight, 0);
+  const padding = 12;
+  const anchorY = Number.isFinite(pointerY)
+    ? clamp(pointerY, margin.top, baselineY)
+    : point.y;
+  let vertical = anchorY + padding;
+  if (vertical > maxVertical) {
+    vertical = anchorY - tooltipHeight - padding;
+  }
+  vertical = clamp(vertical, 0, maxVertical);
+  tooltip.style.transform = `translate(${Math.round(horizontal)}px, ${Math.round(vertical)}px)`;
+}
+
+function hideTooltip(state) {
+  const { tooltip, focusLine, focusCircle } = state;
+  if (tooltip) {
+    tooltip.style.opacity = '0';
+    tooltip.style.visibility = 'hidden';
+  }
+  if (focusLine) {
+    focusLine.style.opacity = '0';
+  }
+  if (focusCircle) {
+    focusCircle.style.opacity = '0';
+  }
+}
+
+function attachPointerHandlers(container, state) {
+  if (state.handlersAttached) {
+    return;
+  }
+
+  const handlePointerMove = (event) => {
+    if (!state.points || state.points.length === 0) {
+      hideTooltip(state);
+      return;
+    }
+
+    const rect = state.svg.getBoundingClientRect();
+    const pointerX = event.clientX - rect.left;
+    const pointerY = event.clientY - rect.top;
+    let closest = state.points[0];
+    let minDistance = Math.abs(pointerX - closest.x);
+
+    for (let idx = 1; idx < state.points.length; idx += 1) {
+      const candidate = state.points[idx];
+      const distance = Math.abs(pointerX - candidate.x);
+      if (distance < minDistance) {
+        minDistance = distance;
+        closest = candidate;
+      }
+    }
+
+    if (!closest) {
+      hideTooltip(state);
+      return;
+    }
+
+    if (state.focusCircle) {
+      state.focusCircle.setAttribute('cx', closest.x.toFixed(2));
+      state.focusCircle.setAttribute('cy', closest.y.toFixed(2));
+      state.focusCircle.style.opacity = '1';
+    }
+
+    if (state.focusLine) {
+      state.focusLine.setAttribute('x1', closest.x.toFixed(2));
+      state.focusLine.setAttribute('x2', closest.x.toFixed(2));
+      state.focusLine.setAttribute('y1', state.margin.top.toFixed(2));
+      state.focusLine.setAttribute(
+        'y2',
+        (state.height - state.margin.bottom).toFixed(2),
+      );
+      state.focusLine.style.opacity = '1';
+    }
+
+    if (state.tooltip) {
+      state.tooltip.innerHTML = formatTooltip(state, closest);
+      updateTooltipPosition(state, closest, pointerY);
+    }
+  };
+
+  const handlePointerLeave = () => {
+    hideTooltip(state);
+  };
+
+  state.overlay.addEventListener('pointermove', handlePointerMove);
+  state.overlay.addEventListener('pointerenter', handlePointerMove);
+  state.overlay.addEventListener('pointerleave', handlePointerLeave);
+
+  state.handlersAttached = true;
+  state.handlePointerMove = handlePointerMove;
+  state.handlePointerLeave = handlePointerLeave;
+}
+
+export function renderLineChart(root, options = {}) {
+  if (!root) {
+    console.error('renderLineChart: root element is required');
+    return null;
+  }
+
+  const container = document.createElement('div');
+  container.className = 'line-chart-container';
+  container.dataset.chartType = 'line';
+  container.style.position = 'relative';
+
+  const svg = createSvgElement('svg', {
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+    viewBox: `0 0 ${DEFAULT_WIDTH} ${DEFAULT_HEIGHT}`,
+    role: 'img',
+    'aria-hidden': 'true',
+    focusable: 'false',
+  });
+  svg.classList.add('line-chart-svg');
+
+  const areaPath = createSvgElement('path', {
+    class: 'line-chart-area',
+    fill: DEFAULT_AREA,
+    stroke: 'none',
+  });
+
+  const linePath = createSvgElement('path', {
+    class: 'line-chart-path',
+    fill: 'none',
+    stroke: DEFAULT_COLOR,
+    'stroke-width': 2,
+    'stroke-linecap': 'round',
+    'stroke-linejoin': 'round',
+  });
+
+  const focusLine = createSvgElement('line', {
+    class: 'line-chart-focus-line',
+    stroke: DEFAULT_COLOR,
+    'stroke-width': 1,
+    'stroke-dasharray': '4 4',
+    opacity: 0,
+  });
+
+  const focusCircle = createSvgElement('circle', {
+    class: 'line-chart-focus-circle',
+    r: 4,
+    fill: '#fff',
+    stroke: DEFAULT_COLOR,
+    'stroke-width': 2,
+    opacity: 0,
+  });
+
+  const overlay = createSvgElement('rect', {
+    class: 'line-chart-overlay',
+    fill: 'transparent',
+    x: 0,
+    y: 0,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+  });
+
+  svg.appendChild(areaPath);
+  svg.appendChild(linePath);
+  svg.appendChild(focusLine);
+  svg.appendChild(focusCircle);
+  svg.appendChild(overlay);
+
+  container.appendChild(svg);
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'chart-tooltip';
+  tooltip.style.position = 'absolute';
+  tooltip.style.top = '0';
+  tooltip.style.left = '0';
+  tooltip.style.pointerEvents = 'none';
+  tooltip.style.opacity = '0';
+  tooltip.style.visibility = 'hidden';
+  container.appendChild(tooltip);
+
+  root.appendChild(container);
+
+  const state = ensureChartState(container);
+  state.svg = svg;
+  state.areaPath = areaPath;
+  state.linePath = linePath;
+  state.focusLine = focusLine;
+  state.focusCircle = focusCircle;
+  state.overlay = overlay;
+  state.tooltip = tooltip;
+  state.xAccessor = options.xAccessor || ((entry) => entry?.date);
+  state.yAccessor = options.yAccessor || ((entry) => entry?.close);
+  state.xFormatter = options.xFormatter || defaultXFormatter;
+  state.yFormatter = options.yFormatter || defaultYFormatter;
+  state.tooltipRenderer = options.tooltipRenderer || defaultTooltipRenderer;
+  state.color = options.color || DEFAULT_COLOR;
+  state.areaColor = options.areaColor || DEFAULT_AREA;
+  state.handlersAttached = false;
+
+  if (!state.xAxis) {
+    const xAxis = document.createElement('div');
+    xAxis.className = 'line-chart-axis line-chart-axis-x';
+    xAxis.style.position = 'absolute';
+    xAxis.style.left = '0';
+    xAxis.style.right = '0';
+    xAxis.style.bottom = '0';
+    xAxis.style.pointerEvents = 'none';
+    xAxis.style.fontSize = DEFAULT_TICK_FONT;
+    xAxis.style.color = 'var(--secondary-text-color)';
+    xAxis.style.display = 'block';
+    container.appendChild(xAxis);
+    state.xAxis = xAxis;
+  }
+
+  if (!state.yAxis) {
+    const yAxis = document.createElement('div');
+    yAxis.className = 'line-chart-axis line-chart-axis-y';
+    yAxis.style.position = 'absolute';
+    yAxis.style.top = '0';
+    yAxis.style.bottom = '0';
+    yAxis.style.left = '0';
+    yAxis.style.pointerEvents = 'none';
+    yAxis.style.fontSize = DEFAULT_TICK_FONT;
+    yAxis.style.color = 'var(--secondary-text-color)';
+    yAxis.style.display = 'block';
+    container.appendChild(yAxis);
+    state.yAxis = yAxis;
+  }
+
+  assignDimensions(state, options.width, options.height, options.margin);
+
+  linePath.setAttribute('stroke', state.color);
+  focusLine.setAttribute('stroke', state.color);
+  focusCircle.setAttribute('stroke', state.color);
+  areaPath.setAttribute('fill', state.areaColor);
+
+  updateLineChart(container, options);
+  attachPointerHandlers(container, state);
+
+  return container;
+}
+
+export function updateLineChart(container, options = {}) {
+  if (!container) {
+    console.error('updateLineChart: container element is required');
+    return;
+  }
+
+  const state = ensureChartState(container);
+  if (!state.svg || !state.linePath || !state.overlay) {
+    console.error('updateLineChart: chart was not initialised with renderLineChart');
+    return;
+  }
+
+  if (options.xAccessor) {
+    state.xAccessor = options.xAccessor;
+  }
+  if (options.yAccessor) {
+    state.yAccessor = options.yAccessor;
+  }
+  if (options.xFormatter) {
+    state.xFormatter = options.xFormatter;
+  }
+  if (options.yFormatter) {
+    state.yFormatter = options.yFormatter;
+  }
+  if (options.tooltipRenderer) {
+    state.tooltipRenderer = options.tooltipRenderer;
+  }
+  if (options.color) {
+    state.color = options.color;
+    state.linePath.setAttribute('stroke', state.color);
+    state.focusLine.setAttribute('stroke', state.color);
+    state.focusCircle.setAttribute('stroke', state.color);
+  }
+  if (options.areaColor) {
+    state.areaColor = options.areaColor;
+    if (state.areaPath) {
+      state.areaPath.setAttribute('fill', state.areaColor);
+    }
+  }
+
+  assignDimensions(state, options.width, options.height, options.margin);
+
+  const { width, height, margin } = state;
+  state.svg.setAttribute('width', width);
+  state.svg.setAttribute('height', height);
+  state.svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+  state.overlay.setAttribute('x', margin.left.toFixed(2));
+  state.overlay.setAttribute('y', margin.top.toFixed(2));
+  state.overlay.setAttribute(
+    'width',
+    Math.max(width - margin.left - margin.right, 0).toFixed(2),
+  );
+  state.overlay.setAttribute(
+    'height',
+    Math.max(height - margin.top - margin.bottom, 0).toFixed(2),
+  );
+
+  const series = Array.isArray(options.series) ? options.series : state.series;
+  state.series = series || [];
+
+  const { points, range } = computePoints(state.series, state, {
+    xAccessor: state.xAccessor,
+    yAccessor: state.yAccessor,
+  });
+  state.points = points;
+  state.range = range;
+
+  if (!points || points.length === 0) {
+    state.linePath.setAttribute('d', '');
+    if (state.areaPath) {
+      state.areaPath.setAttribute('d', '');
+    }
+    hideTooltip(state);
+    updateAxes(state);
+    return;
+  }
+
+  const lineD = buildLinePath(points);
+  state.linePath.setAttribute('d', lineD);
+
+  if (state.areaPath && range) {
+    const baselineY = state.margin.top + range.boundedHeight;
+    const areaD = buildAreaPath(points, baselineY);
+    state.areaPath.setAttribute('d', areaD);
+  }
+
+  updateAxes(state);
+}
+
+function updateAxes(state) {
+  const { xAxis, yAxis, range, margin, width, height, yFormatter } = state;
+  if (!xAxis || !yAxis) {
+    return;
+  }
+
+  if (!range) {
+    xAxis.innerHTML = '';
+    yAxis.innerHTML = '';
+    return;
+  }
+
+  const { minX, maxX, minY, maxY, boundedWidth, boundedHeight } = range;
+
+  const hasValidX = Number.isFinite(minX) && Number.isFinite(maxX) && maxX >= minX;
+  const hasValidY = Number.isFinite(minY) && Number.isFinite(maxY) && maxY >= minY;
+
+  const effectiveWidth = Math.max(boundedWidth, 0);
+  const effectiveHeight = Math.max(boundedHeight, 0);
+
+  xAxis.style.left = `${margin.left}px`;
+  xAxis.style.width = `${effectiveWidth}px`;
+  xAxis.style.top = `${height - margin.bottom + 6}px`;
+  xAxis.innerHTML = '';
+
+  if (hasValidX && effectiveWidth > 0) {
+    const rangeDays = (maxX - minX) / ONE_DAY_MS;
+    const desiredTicks = Math.max(2, Math.min(6, Math.round(effectiveWidth / 140) || 4));
+    const xTicks = generateTimeAxisTicks(state, minX, maxX, desiredTicks, rangeDays);
+    xTicks.forEach(({ positionRatio, label }) => {
+      const tick = document.createElement('div');
+      tick.className = 'line-chart-axis-tick line-chart-axis-tick-x';
+      tick.style.position = 'absolute';
+      tick.style.bottom = '0';
+      tick.style.transform = 'translateX(-50%)';
+      const ratio = clamp(positionRatio, 0, 1);
+      tick.style.left = `${ratio * effectiveWidth}px`;
+      tick.textContent = label;
+      xAxis.appendChild(tick);
+    });
+  }
+
+  yAxis.style.top = `${margin.top}px`;
+  yAxis.style.height = `${effectiveHeight}px`;
+  const yAxisWidth = Math.max(margin.left - 6, 0);
+  yAxis.style.left = '0';
+  yAxis.style.width = `${Math.max(yAxisWidth, 0)}px`;
+  yAxis.innerHTML = '';
+
+  if (hasValidY && effectiveHeight > 0) {
+    const desiredTicks = Math.max(2, Math.min(6, Math.round(effectiveHeight / 60) || 4));
+    const yTicks = generateNumericAxisTicks(minY, maxY, desiredTicks);
+    yTicks.forEach(({ value, positionRatio }) => {
+      const tick = document.createElement('div');
+      tick.className = 'line-chart-axis-tick line-chart-axis-tick-y';
+      tick.style.position = 'absolute';
+      tick.style.left = '0';
+      const clampedRatio = clamp(positionRatio, 0, 1);
+      const top = (1 - clampedRatio) * effectiveHeight;
+      tick.style.top = `${top}px`;
+      tick.textContent = yFormatter ? yFormatter(value) : defaultYFormatter(value);
+      yAxis.appendChild(tick);
+    });
+  }
+}
+
+function computeNiceDomain(minValue, maxValue, desiredTicks = 4) {
+  if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) {
+    return {
+      niceMin: minValue,
+      niceMax: maxValue,
+    };
+  }
+
+  const safeTicks = Math.max(2, desiredTicks);
+
+  if (maxValue === minValue) {
+    const padding = niceStep(Math.abs(minValue) || 1);
+    return {
+      niceMin: minValue - padding,
+      niceMax: maxValue + padding,
+    };
+  }
+
+  const range = maxValue - minValue;
+  const rawStep = range / (safeTicks - 1);
+  const step = niceStep(rawStep);
+  const niceMin = Math.floor(minValue / step) * step;
+  const niceMax = Math.ceil(maxValue / step) * step;
+
+  if (niceMin === niceMax) {
+    return {
+      niceMin: minValue,
+      niceMax: maxValue + step,
+    };
+  }
+
+  return {
+    niceMin,
+    niceMax,
+  };
+}
+
+function generateTimeAxisTicks(state, minTimestamp, maxTimestamp, desiredTicks, rangeDays) {
+  if (!Number.isFinite(minTimestamp) || !Number.isFinite(maxTimestamp) || maxTimestamp < minTimestamp) {
+    return [];
+  }
+
+  if (!Number.isFinite(rangeDays) || rangeDays <= 0) {
+    const label = formatXAxisLabel(state, minTimestamp, rangeDays || 0);
+    return [
+      {
+        positionRatio: 0.5,
+        label,
+      },
+    ];
+  }
+
+  const tickCount = Math.max(2, desiredTicks);
+  const ticks = [];
+  const range = maxTimestamp - minTimestamp;
+  for (let index = 0; index < tickCount; index += 1) {
+    const ratio = tickCount === 1 ? 0.5 : index / (tickCount - 1);
+    const value = minTimestamp + ratio * range;
+    ticks.push({
+      positionRatio: ratio,
+      label: formatXAxisLabel(state, value, rangeDays),
+    });
+  }
+  return ticks;
+}
+
+function formatXAxisLabel(state, timestamp, rangeDays) {
+  const date = new Date(timestamp);
+  if (Number.isFinite(date.getTime())) {
+    if (rangeDays > 1095) {
+      return String(date.getFullYear());
+    }
+    if (rangeDays > 365) {
+      return date.toLocaleDateString('de-DE', {
+        year: 'numeric',
+        month: 'short',
+      });
+    }
+    if (rangeDays > 90) {
+      return date.toLocaleDateString('de-DE', {
+        year: '2-digit',
+        month: 'short',
+      });
+    }
+    if (rangeDays > 30) {
+      return date.toLocaleDateString('de-DE', {
+        day: '2-digit',
+        month: 'short',
+      });
+    }
+    return date.toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+    });
+  }
+
+  return state.xFormatter ? state.xFormatter(timestamp, null, -1) : String(timestamp);
+}
+
+function generateNumericAxisTicks(minValue, maxValue, desiredTicks) {
+  if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) {
+    return [];
+  }
+
+  if (maxValue === minValue) {
+    return [
+      {
+        value: minValue,
+        positionRatio: 0.5,
+      },
+    ];
+  }
+
+  const range = maxValue - minValue;
+  const tickCount = Math.max(2, desiredTicks);
+  const rawStep = range / (tickCount - 1);
+  const step = niceStep(rawStep);
+  const start = Math.floor(minValue / step) * step;
+  const end = Math.ceil(maxValue / step) * step;
+
+  const ticks = [];
+  for (let value = start; value <= end + step / 2; value += step) {
+    const ratio = (value - minValue) / (maxValue - minValue);
+    ticks.push({
+      value,
+      positionRatio: clamp(ratio, 0, 1),
+    });
+  }
+
+  if (ticks.length > tickCount + 2) {
+    return ticks.filter((_, index) => index % 2 === 0);
+  }
+
+  return ticks;
+}
+
+function niceStep(value) {
+  if (!Number.isFinite(value) || value === 0) {
+    return 1;
+  }
+
+  const exponent = Math.floor(Math.log10(Math.abs(value)));
+  const fraction = Math.abs(value) / 10 ** exponent;
+  let niceFraction;
+  if (fraction <= 1) {
+    niceFraction = 1;
+  } else if (fraction <= 2) {
+    niceFraction = 2;
+  } else if (fraction <= 5) {
+    niceFraction = 5;
+  } else {
+    niceFraction = 10;
+  }
+  return niceFraction * 10 ** exponent;
+}

--- a/src/content/elements.ts
+++ b/src/content/elements.ts
@@ -1,0 +1,394 @@
+// @ts-nocheck
+
+/**
+ * HTML rendering helpers mirrored from the legacy dashboard implementation.
+ */
+
+export function formatValue(key, value, row = undefined, context = undefined) {
+  let formatted;
+
+  const toNumber = (v) => {
+    if (typeof v === 'number') {
+      return v;
+    }
+    if (typeof v === 'string' && v.trim() !== '') {
+      const cleaned = v
+        .replace(/\s+/g, '')
+        .replace(/[^0-9,.-]/g, '')
+        .replace(/\.(?=\d{3}(\D|$))/g, '')
+        .replace(',', '.');
+      const parsed = Number.parseFloat(cleaned);
+      return Number.isNaN(parsed) ? Number.NaN : parsed;
+    }
+    return Number.NaN;
+  };
+
+  const safeNumber = (v, minFrac = 2, maxFrac = 2) => {
+    const num = typeof v === 'number' ? v : toNumber(v);
+    if (!Number.isFinite(num)) {
+      return '';
+    }
+    return num.toLocaleString('de-DE', {
+      minimumFractionDigits: minFrac,
+      maximumFractionDigits: maxFrac
+    });
+  };
+
+  const renderMissingValue = (reason = '') => {
+    const title = reason || 'Kein Wert verfügbar';
+    return `<span class="missing-value" role="note" aria-label="${title}" title="${title}">—</span>`;
+  };
+
+  if (['gain_abs', 'gain_pct'].includes(key)) {
+    const missingReason = row?.fx_unavailable
+      ? 'Wechselkurs nicht verfügbar – EUR-Wert unbekannt'
+      : '';
+    if (value == null || (context && context.hasValue === false)) {
+      return renderMissingValue(missingReason);
+    }
+    const numeric = typeof value === 'number' ? value : toNumber(value);
+    if (!Number.isFinite(numeric)) {
+      return renderMissingValue(missingReason);
+    }
+    const symbol = key === 'gain_pct' ? '%' : '€';
+    formatted = safeNumber(numeric) + `&nbsp;${symbol}`;
+    let cls = 'neutral';
+    if (numeric > 0) {
+      cls = 'positive';
+    } else if (numeric < 0) {
+      cls = 'negative';
+    }
+    return `<span class="${cls}">${formatted}</span>`;
+  } else if (key === 'position_count') {
+    const numeric = typeof value === 'number' ? value : toNumber(value);
+    if (!Number.isFinite(numeric)) {
+      return renderMissingValue();
+    }
+    formatted = numeric.toLocaleString('de-DE');
+  } else if (['balance', 'current_value', 'purchase_value'].includes(key)) {
+    const numeric = typeof value === 'number' ? value : toNumber(value);
+    if (!Number.isFinite(numeric)) {
+      if (row?.fx_unavailable) {
+        return renderMissingValue('Wechselkurs nicht verfügbar – EUR-Wert unbekannt');
+      }
+      if (context && context.hasValue === false) {
+        return renderMissingValue();
+      }
+      return renderMissingValue();
+    }
+    formatted = safeNumber(numeric) + '&nbsp;€';
+  } else if (key === 'current_holdings') {
+    // Bestände (Anzahl Anteile) – etwas mehr Präzision (bis 4 Nachkommastellen), aber ohne unnötige Nullen
+    const numeric = typeof value === 'number' ? value : toNumber(value);
+    if (!Number.isFinite(numeric)) {
+      return renderMissingValue();
+    }
+    const hasFraction = Math.abs(numeric % 1) > 0;
+    formatted = numeric.toLocaleString('de-DE', {
+      minimumFractionDigits: hasFraction ? 2 : 0,
+      maximumFractionDigits: 4
+    });
+  } else {
+    formatted = value;
+    if (typeof formatted === 'string') {
+      const MAX_LEN = 60;
+      if (formatted.length > MAX_LEN) {
+        formatted = formatted.slice(0, MAX_LEN - 1) + '…';
+      }
+      // Entferne frühere Präfixe (Abwärtskompatibilität)
+      if (formatted.startsWith('Kontostand ')) {
+        formatted = formatted.substring('Kontostand '.length);
+      } else if (formatted.startsWith('Depotwert ')) {
+        formatted = formatted.substring('Depotwert '.length);
+      }
+    }
+  }
+  if (formatted === '' || formatted == null) {
+    return renderMissingValue();
+  }
+
+  return formatted;
+}
+
+export function makeTable(rows, cols, sumColumns = [], options = {}) {
+  /**
+   * Erweiterung (optional):
+   * options.sortable    -> true | false (default false)
+   * options.defaultSort -> { key: 'name', dir: 'asc' } (nur wirksam falls sortable)
+   *
+   * Bestehende Aufrufer (3 Parameter) bleiben kompatibel.
+   */
+  const { sortable = false, defaultSort = { key: '', dir: 'asc' } } = options || {};
+
+  const escapeAttribute = (value) => {
+    if (value == null) {
+      return '';
+    }
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  };
+
+  let html = '<table><thead><tr>';
+  cols.forEach(c => {
+    const alignClass = c.align === 'right' ? ' class="align-right"' : '';
+    // Falls sortable: th data-sort-key setzen (nur wenn key vorhanden)
+    if (sortable && c.key) {
+      html += `<th${alignClass} data-sort-key="${c.key}">${c.label}</th>`;
+    } else {
+      html += `<th${alignClass}>${c.label}</th>`;
+    }
+  });
+  html += '</tr></thead><tbody>';
+
+  rows.forEach(r => {
+    html += '<tr>';
+    cols.forEach(c => {
+      const alignClass = c.align === 'right' ? ' class="align-right"' : '';
+      html += `<td${alignClass}>${formatValue(c.key, r[c.key], r)}</td>`;
+    });
+    html += '</tr>';
+  });
+
+  // Summen berechnen (unverändert)
+  const sums = {};
+  const sumMeta = {};
+  cols.forEach(c => {
+    if (sumColumns.includes(c.key)) {
+      let total = 0;
+      let hasValue = false;
+      rows.forEach(row => {
+        const v = row[c.key];
+        if (typeof v === 'number' && Number.isFinite(v)) {
+          total += v;
+          hasValue = true;
+        }
+      });
+      sums[c.key] = hasValue ? total : null;
+      sumMeta[c.key] = { hasValue };
+    }
+  });
+
+  if ('gain_abs' in sums) {
+    if ('purchase_value' in sums && sums.purchase_value > 0) {
+      sums['gain_pct'] = (sums['gain_abs'] / sums['purchase_value']) * 100;
+    } else if ('current_value' in sums && sums.current_value !== 0) {
+      sums['gain_pct'] = (sums['gain_abs'] / (sums['current_value'] - sums['gain_abs'])) * 100;
+    }
+  }
+
+  const aggregatedGainPct = Number.isFinite(sums['gain_pct']) ? sums['gain_pct'] : null;
+  let aggregatedGainPctLabel = '';
+  let aggregatedGainPctSign = 'neutral';
+
+  if (aggregatedGainPct != null) {
+    aggregatedGainPctLabel = `${formatNumber(aggregatedGainPct)}\u00a0%`;
+    if (aggregatedGainPct > 0) {
+      aggregatedGainPctSign = 'positive';
+    } else if (aggregatedGainPct < 0) {
+      aggregatedGainPctSign = 'negative';
+    }
+  }
+
+  html += '<tr class="footer-row">';
+  cols.forEach((c, idx) => {
+    const alignClass = c.align === 'right' ? ' class="align-right"' : '';
+    if (idx === 0) {
+      html += `<td${alignClass}>Summe</td>`;
+      return;
+    }
+
+    if (sums[c.key] != null) {
+      let extraAttributes = '';
+      if (c.key === 'gain_abs' && aggregatedGainPctLabel) {
+        extraAttributes = ` data-gain-pct="${escapeAttribute(aggregatedGainPctLabel)}" data-gain-sign="${escapeAttribute(aggregatedGainPctSign)}"`;
+      }
+      html += `<td${alignClass}${extraAttributes}>${formatValue(c.key, sums[c.key], undefined, sumMeta[c.key])}</td>`;
+      return;
+    }
+
+    if (c.key === 'gain_pct' && sums['gain_pct'] != null) {
+      html += `<td${alignClass}>${formatValue('gain_pct', sums['gain_pct'], undefined, sumMeta[c.key])}</td>`;
+      return;
+    }
+
+    const fallbackContext = sumMeta[c.key] ?? { hasValue: false };
+    html += `<td${alignClass}>${formatValue(c.key, null, undefined, fallbackContext)}</td>`;
+  });
+  html += '</tr>';
+
+  html += '</tbody></table>';
+
+  // Falls sortable: Default-Sort-Metadaten injizieren (nicht doppelt parsen falls nicht nötig)
+  if (sortable) {
+    try {
+      const tpl = document.createElement('template');
+      tpl.innerHTML = html.trim();
+      const table = tpl.content.querySelector('table');
+      if (table) {
+        table.classList.add('sortable-table');
+        if (defaultSort?.key) {
+          table.dataset.defaultSort = defaultSort.key;
+          table.dataset.defaultDir = defaultSort.dir === 'desc' ? 'desc' : 'asc';
+        }
+        return table.outerHTML;
+      }
+    } catch (e) {
+      console.warn("makeTable(sortable): Injection fehlgeschlagen:", e);
+    }
+  }
+
+  return html;
+}
+
+export function createHeaderCard(headerTitle, meta) {
+  const headerCard = document.createElement('div');
+  headerCard.className = 'header-card';
+
+  headerCard.innerHTML = `
+    <div class="header-content">
+      <button id="nav-left" class="nav-arrow" aria-label="Vorherige Seite">
+        <svg viewBox="0 0 24 24">
+          <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
+        </svg>
+      </button>
+      <h1 id="headerTitle">${headerTitle}</h1>
+      <button id="nav-right" class="nav-arrow" aria-label="Nächste Seite">
+        <svg viewBox="0 0 24 24">
+          <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"></path>
+        </svg>
+      </button>
+    </div>
+    <div id="headerMeta" class="meta">${meta}</div>
+  `;
+
+  return headerCard;
+}
+
+// === NEU: Vereinheitlichte Format-Helfer für andere Module (z.B. overview.js) ===
+export function formatNumber(value, minFrac = 2, maxFrac = 2) {
+  return (isNaN(value) ? 0 : value).toLocaleString('de-DE', {
+    minimumFractionDigits: minFrac,
+    maximumFractionDigits: maxFrac
+  });
+}
+
+export function formatGain(value) {
+  const num = isNaN(value) ? 0 : value;
+  let cls = 'neutral';
+  if (num > 0) {
+    cls = 'positive';
+  } else if (num < 0) {
+    cls = 'negative';
+  }
+  return `<span class="${cls}">${formatNumber(num)}&nbsp;€</span>`;
+}
+
+export function formatGainPct(value) {
+  const num = isNaN(value) ? 0 : value;
+  let cls = 'neutral';
+  if (num > 0) {
+    cls = 'positive';
+  } else if (num < 0) {
+    cls = 'negative';
+  }
+  return `<span class="${cls}">${formatNumber(num)}&nbsp;%</span>`;
+}
+
+/**
+ * Neue Utility: sortTableRows
+ * Sortiert die Datenzeilen (<tr>) einer Tabelle anhand eines Keys.
+ *
+ * @param {HTMLTableElement} tableEl  Ziel-Tabelle
+ * @param {string} key                Daten-Key (muss mit data-sort-key im TH oder Positions-Mapping übereinstimmen)
+ * @param {'asc'|'desc'} dir          Sortierrichtung
+ * @param {boolean} isPositions       true => Positions-Spalten-Mapping verwenden
+ * @returns {HTMLTableRowElement[]}   Array der neu angeordneten Daten-Zeilen (ohne Footer)
+ *
+ * Erkennung Zahl vs. String:
+ *  - Entfernt NBSP, €, %, Tausenderpunkte
+ *  - Wandelt Komma in Punkt
+ *  - Wenn parseFloat ein valides Zahlenergebnis liefert und der ursprüngliche Text
+ *    nicht komplett alphabetisch ist -> numerischer Vergleich; sonst localeCompare.
+ *
+ * Footer-Zeile ('.footer-row') bleibt am Ende erhalten.
+ */
+export function sortTableRows(tableEl, key, dir = 'asc', isPositions = false) {
+  if (!tableEl) return [];
+  const tbody = tableEl.querySelector('tbody');
+  if (!tbody) return [];
+
+  const footer = tbody.querySelector('tr.footer-row');
+  const rows = Array
+    .from(tbody.querySelectorAll('tr'))
+    .filter(r => r !== footer);
+
+  // Spaltenindex bestimmen
+  let colIdx = -1;
+  if (isPositions) {
+    const posMap = {
+      name: 0,
+      current_holdings: 1,
+      purchase_value: 2,
+      current_value: 3,
+      gain_abs: 4,
+      gain_pct: 5
+    };
+    colIdx = posMap[key];
+  } else {
+    // Generisch über thead th[data-sort-key]
+    const ths = Array.from(tableEl.querySelectorAll('thead th'));
+    for (let i = 0; i < ths.length; i++) {
+      if (ths[i].getAttribute('data-sort-key') === key) {
+        colIdx = i;
+        break;
+      }
+    }
+  }
+  if (colIdx == null || colIdx < 0) return rows;
+
+  const toNumber = (txt) => {
+    if (txt == null) return NaN;
+    const cleaned = txt
+      .replace(/\u00A0/g, ' ')
+      .replace(/[%€]/g, '')
+      .replace(/\./g, '')
+      .replace(/,/g, '.')
+      .replace(/[^\d.-]/g, '')
+      .trim();
+    if (!cleaned) return NaN;
+    const num = parseFloat(cleaned);
+    return Number.isFinite(num) ? num : NaN;
+  };
+
+  rows.sort((a, b) => {
+    const aTxt = a.cells[colIdx]?.textContent.trim() || '';
+    const bTxt = b.cells[colIdx]?.textContent.trim() || '';
+
+    const aNum = toNumber(aTxt);
+    const bNum = toNumber(bTxt);
+
+    let cmp;
+    if (!isNaN(aNum) && !isNaN(bNum) && (aTxt.match(/[0-9]/) || bTxt.match(/[0-9]/))) {
+      cmp = aNum - bNum;
+    } else {
+      cmp = aTxt.localeCompare(bTxt, 'de', { sensitivity: 'base' });
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+
+  // Re-Anordnung im DOM
+  rows.forEach(r => tbody.appendChild(r));
+  if (footer) tbody.appendChild(footer);
+
+  // Visuelle Indikatoren aktualisieren (optional generisch)
+  tableEl.querySelectorAll('thead th.sort-active').forEach(th => {
+    th.classList.remove('sort-active', 'dir-asc', 'dir-desc');
+  });
+  const activeTh = tableEl.querySelector(`thead th[data-sort-key="${key}"]`);
+  if (activeTh) {
+    activeTh.classList.add('sort-active', dir === 'asc' ? 'dir-asc' : 'dir-desc');
+  }
+
+  return rows;
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,862 @@
+// @ts-nocheck
+
+/**
+ * Mirrors the legacy dashboard controller for initial TypeScript migration.
+ */
+
+import { addSwipeEvents } from './interaction/tab_control.js';
+import { renderDashboard, attachPortfolioToggleHandler } from './tabs/overview.js';
+import { registerSecurityDetailTab } from './tabs/security_detail.js';
+import {
+  handleAccountUpdate,
+  handleLastFileUpdate,
+  handlePortfolioUpdate,
+  handlePortfolioPositionsUpdate
+} from './data/updateConfigsWS.js';
+import { getEntryId } from './data/api.js';
+
+const STICKY_HEADER_ANCHOR_ID = 'pp-reader-sticky-anchor';
+
+const OVERVIEW_TAB_KEY = 'overview';
+
+const baseTabs = [
+  { key: OVERVIEW_TAB_KEY, title: 'Dashboard', render: renderDashboard }
+];
+
+const detailTabRegistry = new Map();
+const detailTabOrder = [];
+const securityTabLookup = new Map();
+const SECURITY_DETAIL_TAB_PREFIX = 'security:';
+
+function extractSecurityUuidFromKey(key) {
+  if (typeof key !== 'string' || !key.startsWith(SECURITY_DETAIL_TAB_PREFIX)) {
+    return null;
+  }
+
+  const uuid = key.slice(SECURITY_DETAIL_TAB_PREFIX.length);
+  return uuid || null;
+}
+
+let securityDetailTabFactory = null;
+let navigationInProgress = false;
+let lastClosedSecurityUuid = null;
+
+function tryReopenLastDetail() {
+  if (!lastClosedSecurityUuid) {
+    return false;
+  }
+
+  const reopened = openSecurityDetail(lastClosedSecurityUuid);
+  if (!reopened) {
+    lastClosedSecurityUuid = null;
+  }
+  return reopened;
+}
+
+function getVisibleTabs() {
+  const detailTabs = detailTabOrder
+    .map((key) => detailTabRegistry.get(key))
+    .filter(Boolean);
+
+  return [...baseTabs, ...detailTabs];
+}
+
+function rememberCurrentPageScroll() {
+  try {
+    const dashboardElement = findDashboardElement();
+    if (dashboardElement && typeof dashboardElement.rememberScrollPosition === 'function') {
+      dashboardElement.rememberScrollPosition();
+    }
+  } catch (error) {
+    console.warn('rememberCurrentPageScroll: konnte Scroll-Position nicht sichern', error);
+  }
+}
+
+function clampPageIndex(index) {
+  const tabs = getVisibleTabs();
+  if (!tabs.length) {
+    return 0;
+  }
+  if (index < 0) {
+    return 0;
+  }
+  if (index >= tabs.length) {
+    return tabs.length - 1;
+  }
+  return index;
+}
+
+async function navigateToPage(targetIndex, root, hass, panel) {
+  const tabs = getVisibleTabs();
+  const clampedIndex = clampPageIndex(targetIndex);
+  if (clampedIndex === currentPage) {
+    if (targetIndex > currentPage) {
+      tryReopenLastDetail();
+    }
+    return;
+  }
+
+  rememberCurrentPageScroll();
+
+  const currentTab = tabs[currentPage];
+  const currentSecurityUuid = extractSecurityUuidFromKey(currentTab?.key);
+  let nextIndex = clampedIndex;
+
+  if (currentSecurityUuid) {
+    const intendedTarget = tabs[clampedIndex];
+    if (intendedTarget?.key === OVERVIEW_TAB_KEY) {
+      const closed = closeSecurityDetail(currentSecurityUuid, { suppressRender: true });
+      if (closed) {
+        const updatedTabs = getVisibleTabs();
+        const overviewIndex = updatedTabs.findIndex((tab) => tab.key === OVERVIEW_TAB_KEY);
+        nextIndex = overviewIndex >= 0 ? overviewIndex : 0;
+      }
+    }
+  }
+
+  if (navigationInProgress) {
+    return;
+  }
+
+  navigationInProgress = true;
+  try {
+    currentPage = clampPageIndex(nextIndex);
+    await renderTab(root, hass, panel);
+  } catch (error) {
+    console.error('navigateToPage: Fehler beim Rendern des Tabs', error);
+  } finally {
+    navigationInProgress = false;
+  }
+}
+
+function navigateByDelta(delta, root, hass, panel) {
+  navigateToPage(currentPage + delta, root, hass, panel);
+}
+
+export function registerDetailTab(key, descriptor) {
+  if (!key || !descriptor || typeof descriptor.render !== 'function') {
+    console.error('registerDetailTab: Ungültiger Tab-Descriptor', key, descriptor);
+    return;
+  }
+
+  const securityUuid = extractSecurityUuidFromKey(key);
+  if (securityUuid) {
+    const existingKey = securityTabLookup.get(securityUuid);
+    if (existingKey && existingKey !== key) {
+      unregisterDetailTab(existingKey);
+    }
+  }
+
+  const normalizedDescriptor = {
+    ...descriptor,
+    key,
+  };
+
+  detailTabRegistry.set(key, normalizedDescriptor);
+
+  if (securityUuid) {
+    securityTabLookup.set(securityUuid, key);
+  }
+
+  if (!detailTabOrder.includes(key)) {
+    detailTabOrder.push(key);
+  }
+}
+
+export function unregisterDetailTab(key) {
+  if (!key) {
+    return;
+  }
+
+  const descriptor = detailTabRegistry.get(key);
+  if (descriptor && typeof descriptor.cleanup === 'function') {
+    try {
+      descriptor.cleanup({ key });
+    } catch (error) {
+      console.error('unregisterDetailTab: Fehler beim Ausführen von cleanup', error);
+    }
+  }
+
+  detailTabRegistry.delete(key);
+
+  const index = detailTabOrder.indexOf(key);
+  if (index >= 0) {
+    detailTabOrder.splice(index, 1);
+  }
+
+  const securityUuid = extractSecurityUuidFromKey(key);
+  if (securityUuid && securityTabLookup.get(securityUuid) === key) {
+    securityTabLookup.delete(securityUuid);
+  }
+}
+
+export function hasDetailTab(key) {
+  return detailTabRegistry.has(key);
+}
+
+export function getDetailTabDescriptor(key) {
+  return detailTabRegistry.get(key) || null;
+}
+
+export function setSecurityDetailTabFactory(factory) {
+  if (factory != null && typeof factory !== 'function') {
+    console.error('setSecurityDetailTabFactory: Erwartet Funktion oder null', factory);
+    return;
+  }
+
+  securityDetailTabFactory = factory || null;
+}
+
+function getSecurityDetailTabKey(securityUuid) {
+  return `${SECURITY_DETAIL_TAB_PREFIX}${securityUuid}`;
+}
+
+function findDashboardElement() {
+  const registered = window.__ppReaderDashboardElements;
+  if (registered instanceof Set) {
+    for (const element of registered) {
+      if (element && element.isConnected) {
+        return element;
+      }
+    }
+  }
+
+  const direct = document.querySelector('pp-reader-dashboard');
+  if (direct) {
+    return direct;
+  }
+
+  const panelElements = document.querySelectorAll('pp-reader-panel');
+  for (const panelElement of panelElements) {
+    if (!panelElement || !panelElement.shadowRoot) {
+      continue;
+    }
+
+    const nested = panelElement.shadowRoot.querySelector('pp-reader-dashboard');
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function requestDashboardRender() {
+  const dashboardElement = findDashboardElement();
+  if (!dashboardElement) {
+    console.warn('requestDashboardRender: Kein pp-reader-dashboard Element gefunden');
+    return;
+  }
+
+  if (typeof dashboardElement._renderIfInitialized === 'function') {
+    dashboardElement._renderIfInitialized();
+    return;
+  }
+
+  if (typeof dashboardElement._render === 'function') {
+    dashboardElement._render();
+  }
+}
+
+export function openSecurityDetail(securityUuid) {
+  if (!securityUuid) {
+    console.error('openSecurityDetail: Ungültige securityUuid', securityUuid);
+    return false;
+  }
+
+  const tabKey = getSecurityDetailTabKey(securityUuid);
+  let descriptor = getDetailTabDescriptor(tabKey);
+
+  if (!descriptor && typeof securityDetailTabFactory === 'function') {
+    try {
+      const maybeDescriptor = securityDetailTabFactory(securityUuid);
+      if (maybeDescriptor && typeof maybeDescriptor.render === 'function') {
+        registerDetailTab(tabKey, maybeDescriptor);
+        descriptor = getDetailTabDescriptor(tabKey);
+      } else {
+        console.error('openSecurityDetail: Factory lieferte ungültigen Descriptor', maybeDescriptor);
+      }
+    } catch (error) {
+      console.error('openSecurityDetail: Fehler beim Erzeugen des Tab-Descriptors', error);
+    }
+  }
+
+  if (!descriptor) {
+    console.warn(`openSecurityDetail: Kein Detail-Tab für ${securityUuid} verfügbar`);
+    return false;
+  }
+
+  rememberCurrentPageScroll();
+
+  const tabs = getVisibleTabs();
+  let targetIndex = tabs.findIndex((tab) => tab.key === tabKey);
+
+  if (targetIndex === -1) {
+    const updatedTabs = getVisibleTabs();
+    targetIndex = updatedTabs.findIndex((tab) => tab.key === tabKey);
+    if (targetIndex === -1) {
+      console.error('openSecurityDetail: Tab nach Registrierung nicht auffindbar');
+      return false;
+    }
+  }
+
+  currentPage = targetIndex;
+  lastClosedSecurityUuid = null;
+  requestDashboardRender();
+  return true;
+}
+
+export function closeSecurityDetail(securityUuid, options = {}) {
+  if (!securityUuid) {
+    console.error('closeSecurityDetail: Ungültige securityUuid', securityUuid);
+    return false;
+  }
+
+  const { suppressRender = false } = options;
+
+  const tabKey = getSecurityDetailTabKey(securityUuid);
+  if (!hasDetailTab(tabKey)) {
+    return false;
+  }
+
+  const tabsBefore = getVisibleTabs();
+  const tabIndexBefore = tabsBefore.findIndex((tab) => tab.key === tabKey);
+  const wasActive = tabIndexBefore === currentPage;
+
+  unregisterDetailTab(tabKey);
+
+  const tabsAfter = getVisibleTabs();
+  if (!tabsAfter.length) {
+    currentPage = 0;
+    if (!suppressRender) {
+      requestDashboardRender();
+    }
+    return true;
+  }
+
+  lastClosedSecurityUuid = securityUuid;
+
+  if (wasActive) {
+    const overviewIndex = tabsAfter.findIndex((tab) => tab.key === OVERVIEW_TAB_KEY);
+    if (overviewIndex >= 0) {
+      currentPage = overviewIndex;
+    } else {
+      currentPage = Math.min(Math.max(tabIndexBefore - 1, 0), tabsAfter.length - 1);
+    }
+  } else if (currentPage >= tabsAfter.length) {
+    currentPage = Math.max(0, tabsAfter.length - 1);
+  }
+
+  if (!suppressRender) {
+    requestDashboardRender();
+  }
+  return true;
+}
+
+let currentPage = 0;
+let observer; // Globale Variable für Debugging
+
+async function renderTab(root, hass, panel) {
+  // Fallback: Panel-Konfiguration aus hass.panels ableiten, falls panel undefined
+  let effectivePanel = panel;
+  if (!effectivePanel && hass?.panels) {
+    // Versuche spezifische Keys
+    effectivePanel =
+      hass.panels.ppreader ||
+      hass.panels.pp_reader ||
+      // Suche nach unserem Webcomponent
+      Object.values(hass.panels).find(p => p?.webcomponent_name === 'pp-reader-panel') ||
+      null;
+  }
+
+  const tabs = getVisibleTabs();
+  if (currentPage >= tabs.length) {
+    currentPage = Math.max(0, tabs.length - 1);
+  }
+
+  const tab = tabs[currentPage];
+  if (!tab || !tab.render) {
+    console.error("renderTab: Kein gültiger Tab oder keine render-Methode gefunden!");
+    return;
+  }
+
+  let content;
+  try {
+    content = await tab.render(root, hass, effectivePanel); // effectivePanel statt panel
+  } catch (error) {
+    console.error("renderTab: Fehler beim Rendern des Tabs:", error);
+    root.innerHTML = `<div class="card"><h2>Fehler</h2><pre>${(error && error.message) || error}</pre></div>`;
+    return;
+  }
+
+  if (!root) {
+    console.error("renderTab: Root-Element nicht gefunden!");
+    return;
+  }
+
+  root.innerHTML = content;
+
+  // NEU (Section 6): Scoped Listener für Portfolio-Expand nur für Overview-Tab (Index 0 / Titel 'Dashboard')
+  if (tab.render === renderDashboard) {
+    attachPortfolioToggleHandler(root);
+  }
+
+  // Warte, bis die `.header-card` im DOM verfügbar ist
+  const waitForHeaderCard = () => new Promise((resolve) => {
+    const interval = setInterval(() => {
+      const headerCard = root.querySelector('.header-card');
+      if (headerCard) {
+        clearInterval(interval);
+        resolve(headerCard);
+      }
+    }, 50);
+  });
+
+  const headerCard = await waitForHeaderCard();
+  if (!headerCard) {
+    console.error("Header-Card nicht gefunden!");
+    return;
+  }
+
+  // Sticky-Anchor für IntersectionObserver erstellen (scoped innerhalb des Root-Elements)
+  let anchor = root.querySelector(`#${STICKY_HEADER_ANCHOR_ID}`);
+  if (!anchor) {
+    anchor = document.createElement('div');
+    anchor.id = STICKY_HEADER_ANCHOR_ID;
+    headerCard.parentNode.insertBefore(anchor, headerCard);
+  }
+
+  // Navigation und Scrollverhalten einrichten
+  setupNavigation(root, hass, panel); // Lokale Parameter übergeben
+  setupSwipeOnHeaderCard(root, hass, panel); // Lokale Parameter übergeben
+  setupHeaderScrollBehavior(root);
+}
+
+function setupHeaderScrollBehavior(root) {
+  const headerCard = root.querySelector('.header-card');
+  const scrollBorder = root;
+  const anchor = root.querySelector(`#${STICKY_HEADER_ANCHOR_ID}`);
+
+  if (!headerCard || !scrollBorder || !anchor) {
+    console.error("Fehlende Elemente für das Scrollverhalten: headerCard, scrollBorder oder anchor.");
+    return;
+  }
+
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      if (!entry.isIntersecting) {
+        headerCard.classList.add('sticky');
+      } else {
+        headerCard.classList.remove('sticky');
+      }
+    },
+    {
+      root: null,
+      rootMargin: `0px 0px 0px 0px`,
+      threshold: 0
+    }
+  );
+
+  observer.observe(anchor);
+}
+
+function setupSwipeOnHeaderCard(root, hass, panel) {
+  const headerCard = root.querySelector('.header-card');
+  if (!headerCard) {
+    console.error("Header-Card nicht gefunden!");
+    return;
+  }
+
+  addSwipeEvents(
+    headerCard,
+    () => navigateByDelta(1, root, hass, panel),
+    () => navigateByDelta(-1, root, hass, panel)
+  );
+}
+
+function setupNavigation(root, hass, panel) {
+  const headerCard = root.querySelector('.header-card');
+  if (!headerCard) {
+    console.error("Header-Card nicht gefunden!");
+    return;
+  }
+
+  const navLeft = headerCard.querySelector('#nav-left');
+  const navRight = headerCard.querySelector('#nav-right');
+
+  if (!navLeft || !navRight) {
+    console.error("Navigationspfeile nicht gefunden!");
+    return;
+  }
+
+  navLeft.addEventListener('click', () => {
+    navigateByDelta(-1, root, hass, panel);
+  });
+
+  navRight.addEventListener('click', () => {
+    navigateByDelta(1, root, hass, panel);
+  });
+
+  updateNavigationState(headerCard); // Initialer Zustand der Navigationspfeile
+}
+
+function updateNavigationState(headerCard) {
+  const navLeft = headerCard.querySelector('#nav-left');
+  const navRight = headerCard.querySelector('#nav-right');
+
+  if (navLeft) {
+    if (currentPage === 0) {
+      navLeft.disabled = true;
+      navLeft.classList.add('disabled');
+    } else {
+      navLeft.disabled = false;
+      navLeft.classList.remove('disabled');
+    }
+  }
+
+  if (navRight) {
+    const tabs = getVisibleTabs();
+    const atEnd = currentPage === tabs.length - 1;
+    const shouldEnable = !atEnd || !!lastClosedSecurityUuid;
+    navRight.disabled = !shouldEnable;
+    navRight.classList.toggle('disabled', !shouldEnable);
+  }
+}
+
+class PPReaderDashboard extends HTMLElement {
+  constructor() {
+    super();
+    this._root = document.createElement('div');
+    this._root.className = 'pp-reader-dashboard';
+    this.appendChild(this._root);
+
+    this._lastPanel = null;
+    this._lastNarrow = null;
+    this._lastRoute = null;
+    this._lastPage = null;
+    this._scrollPositions = {}; // Speichert die Scroll-Position pro Tab
+
+    this._unsubscribeEvents = null; // Event-Bus-Listener für Updates
+    this._initialized = false; // Initialisierungs-Flag
+    this._hasNewData = false; // Flag für neue Daten
+    this._pendingUpdates = []; // Gespeicherte WS-Updates zur Re-Anwendung nach Re-Renders
+    this._entryIdWaitWarned = false; // Verhindert Log-Spam während wir auf entry_id warten
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._checkInitialization(); // Überprüfe die Initialisierung
+  }
+
+  set panel(panel) {
+    if (this._panel === panel) {
+      return;
+    }
+    this._panel = panel;
+    // Debug
+    // console.debug("PPReaderDashboard: panel setter", panel);
+    this._checkInitialization();
+  }
+
+  set narrow(narrow) {
+    if (this._narrow === narrow) {
+      return;
+    }
+    this._narrow = narrow;
+    this._renderIfInitialized(); // Rendere nur, wenn initialisiert
+  }
+
+  set route(route) {
+    if (this._route === route) {
+      return;
+    }
+    this._route = route;
+    this._renderIfInitialized(); // Rendere nur, wenn initialisiert
+  }
+
+  connectedCallback() {
+    this._checkInitialization();
+  }
+
+  disconnectedCallback() {
+    // Wenn das Element aus dem DOM fliegt, sauber abmelden
+    if (typeof this._unsubscribeEvents === "function") {
+      this._unsubscribeEvents();
+      // console.debug("PPReaderDashboard: Event-Listener entfernt");
+      this._unsubscribeEvents = null;
+    }
+    super.disconnectedCallback && super.disconnectedCallback();
+  }
+
+  _checkInitialization() {
+    if (!this._hass || this._initialized) return;
+
+    // Panel-Fallback falls nicht gesetzt
+    if (!this._panel && this._hass.panels) {
+      this._panel =
+        this._hass.panels.ppreader ||
+        this._hass.panels.pp_reader ||
+        Object.values(this._hass.panels).find(p => p?.config?._panel_custom?.module_url?.includes('pp_reader_dashboard')) ||
+        null;
+    }
+
+    const entryId = getEntryId(this._hass, this._panel);
+    if (!entryId) {
+      if (!this._entryIdWaitWarned) {
+        console.warn("PPReaderDashboard: kein entry_id ermittelbar – warte auf Panel-Konfiguration.");
+        this._entryIdWaitWarned = true;
+      }
+      return;
+    }
+
+    this._entryIdWaitWarned = false;
+    console.debug("PPReaderDashboard: entry_id (fallback) =", entryId);
+    this._initialized = true;
+    this._initializeEventListeners(entryId);
+    this._render();
+  }
+
+  _initializeEventListeners(entryId) {
+    // Wenn schon mal registriert, vorher sauber abmelden
+    if (this._unsubscribeEvents) {
+      this._unsubscribeEvents();
+      this._unsubscribeEvents = null;
+    }
+
+    const conn = this._hass?.connection;
+    if (!conn || typeof conn.subscribeEvents !== "function") {
+      console.error("PPReaderDashboard: keine valide WebSocket-Verbindung oder subscribeEvents fehlt");
+      return;
+    }
+
+    // Korrektur: Richtiger Event-Typ ist 'panels_updated' (Wert von HA CONST EVENT_PANELS_UPDATED)
+    // Zur Sicherheit auch Legacy-Fehlwert registrieren (wird einfach nie feuern)
+    const eventTypes = ["panels_updated"]; // früher fälschlich: "EVENT_PANELS_UPDATED"
+
+    const subs = [];
+    Promise.all(
+      eventTypes.map(et =>
+        conn
+          .subscribeEvents(this._handleBusEvent.bind(this), et)
+          .then(unsub => {
+            if (typeof unsub === "function") {
+              subs.push(unsub);
+              console.debug("PPReaderDashboard: subscribed to", et);
+            } else {
+              console.error("PPReaderDashboard: subscribeEvents lieferte kein Unsubscribe-Func für", et, unsub);
+            }
+          })
+          .catch(err => {
+            console.error("PPReaderDashboard: Fehler bei subscribeEvents für", et, err);
+          })
+      )
+    ).then(() => {
+      this._unsubscribeEvents = () => {
+        subs.forEach(f => {
+          try { f(); } catch (e) { /* noop */ }
+        });
+        console.debug("PPReaderDashboard: alle Event-Subscriptions entfernt");
+      };
+    });
+  }
+
+  _removeEventListeners() {
+    if (typeof this._unsubscribeEvents === "function") {
+      try {
+        this._unsubscribeEvents();
+        this._unsubscribeEvents = null;
+        // console.debug("PPReaderDashboard: Event-Listener erfolgreich entfernt.");
+      } catch (error) {
+        console.error("PPReaderDashboard: Fehler beim Entfernen der Event-Listener:", error);
+      }
+    } else {
+      console.warn("PPReaderDashboard: Kein gültiger Event-Listener zum Entfernen gefunden.");
+    }
+  }
+
+  _handleBusEvent(event) {
+    const currentEntryId = getEntryId(this._hass, this._panel);
+    if (!currentEntryId || event.data.entry_id !== currentEntryId) return;
+
+    console.debug("PPReaderDashboard: Bus-Update erhalten", event.data);
+
+    this._queueUpdate(event.data.data_type, event.data.data);
+    // Daten direkt ins Rendern einfließen lassen
+    this._doRender(event.data.data_type, event.data.data);
+  }
+
+  _doRender(dataType, pushedData) {
+    if (dataType === "accounts") {
+      handleAccountUpdate(pushedData, this._root);
+    } else if (dataType === "last_file_update") {
+      handleLastFileUpdate(pushedData, this._root);
+    } else if (dataType === "portfolio_values") {
+      handlePortfolioUpdate(pushedData, this._root);
+    } else if (dataType === "portfolio_positions") {
+      // NEU: Einzelpositions-Update für ein bestimmtes Depot
+      handlePortfolioPositionsUpdate(pushedData, this._root);
+    } else {
+      console.warn("PPReaderDashboard: Unbekannter Datentyp:", dataType);
+    }
+  }
+
+  _queueUpdate(dataType, pushedData) {
+    if (!dataType) {
+      return;
+    }
+
+    if (!Array.isArray(this._pendingUpdates)) {
+      this._pendingUpdates = [];
+    }
+
+    const entry = { type: dataType, data: this._cloneData(pushedData) };
+
+    let index = -1;
+    if (dataType === "portfolio_positions" && pushedData && pushedData.portfolio_uuid) {
+      index = this._pendingUpdates.findIndex(
+        (item) =>
+          item.type === dataType &&
+          item.data &&
+          item.data.portfolio_uuid === pushedData.portfolio_uuid
+      );
+    } else {
+      index = this._pendingUpdates.findIndex(item => item.type === dataType);
+    }
+
+    if (index >= 0) {
+      this._pendingUpdates[index] = entry;
+    } else {
+      this._pendingUpdates.push(entry);
+    }
+
+    this._hasNewData = true;
+  }
+
+  _cloneData(data) {
+    if (data == null) {
+      return data;
+    }
+    try {
+      if (typeof structuredClone === "function") {
+        return structuredClone(data);
+      }
+    } catch (err) {
+      console.warn("PPReaderDashboard: structuredClone fehlgeschlagen, falle auf JSON zurück", err);
+    }
+    try {
+      return JSON.parse(JSON.stringify(data));
+    } catch (err) {
+      console.warn("PPReaderDashboard: JSON-Clone fehlgeschlagen, referenziere Originaldaten", err);
+      return data;
+    }
+  }
+
+  _reapplyPendingUpdates() {
+    if (!Array.isArray(this._pendingUpdates) || this._pendingUpdates.length === 0) {
+      return;
+    }
+
+    for (const item of this._pendingUpdates) {
+      try {
+        this._doRender(item.type, this._cloneData(item.data));
+      } catch (error) {
+        console.error("PPReaderDashboard: Fehler beim erneuten Anwenden eines Updates", item, error);
+      }
+    }
+  }
+
+  _renderIfInitialized() {
+    // Rendere nur, wenn die Initialisierung abgeschlossen ist
+    if (this._initialized) {
+      this._render();
+    }
+  }
+
+  rememberScrollPosition(page = currentPage) {
+    if (!this._root) {
+      return;
+    }
+
+    const targetPage = Number.isInteger(page) ? page : currentPage;
+    if (targetPage == null) {
+      return;
+    }
+
+    this._scrollPositions[targetPage] = this._root.scrollTop || 0;
+  }
+
+  _render() {
+    if (!this._hass) {
+      console.warn("pp-reader-dashboard: noch kein hass, überspringe _render()");
+      return;
+    }
+    if (!this._initialized) {
+      console.debug("pp-reader-dashboard: _render aufgerufen bevor initialisiert");
+      return;
+    }
+
+    // Prüfen, ob ein Render notwendig ist
+    const page = currentPage;
+    if (
+      !this._hasNewData && // Nur rendern, wenn neue Daten vorliegen
+      this._panel === this._lastPanel &&
+      this._narrow === this._lastNarrow &&
+      this._route === this._lastRoute &&
+      this._lastPage === page
+    ) {
+      // console.log("pp-reader-dashboard: keine Änderungen → skip render");
+      return;
+    }
+
+    // Alte Scroll-Position merken (pro Tab)
+    if (this._lastPage != null) {
+      this._scrollPositions[this._lastPage] = this._root.scrollTop;
+    }
+
+    const maybePromise = renderTab(this._root, this._hass, this._panel);
+    if (maybePromise && typeof maybePromise.then === "function") {
+      maybePromise
+        .then(() => {
+          this._afterRender(page);
+        })
+        .catch((error) => {
+          console.error("PPReaderDashboard: Fehler beim Rendern des Tabs", error);
+          this._afterRender(page);
+        });
+    } else {
+      this._afterRender(page);
+    }
+  }
+
+  _afterRender(page) {
+    if (!this._root) {
+      return;
+    }
+
+    const restore = this._scrollPositions[page] || 0;
+    this._root.scrollTop = restore;
+
+    this._lastPanel = this._panel;
+    this._lastNarrow = this._narrow;
+    this._lastRoute = this._route;
+    this._lastPage = page;
+
+    try {
+      this._reapplyPendingUpdates();
+    } catch (error) {
+      console.error("PPReaderDashboard: Fehler beim Wiederanlegen der Updates", error);
+    }
+
+    this._hasNewData = false;
+  }
+}
+
+if (!customElements.get('pp-reader-dashboard')) {
+  customElements.define('pp-reader-dashboard', PPReaderDashboard);
+}
+
+console.log("PPReader dashboard.js v20250914b geladen");
+
+registerSecurityDetailTab({
+  setSecurityDetailTabFactory,
+});

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,0 +1,168 @@
+// @ts-nocheck
+
+/**
+ * Home Assistant websocket API helpers carried over for TypeScript migration.
+ */
+
+function deriveEntryId(hass, panelConfig) {
+  // Direkt gesetzte einfache Variante (neuer Panelspeicher)
+  let entry_id = panelConfig?.config?.entry_id;
+
+  // Neu: Home Assistant liefert den entry_id-Wert inzwischen auch auf Root-Ebene
+  // des panelConfig-Objekts. Ohne diesen Fallback konnten wir in seltenen Fällen
+  // keinen entry_id bestimmen (z.B. wenn hass.panels noch nicht gefüllt war),
+  // wodurch sämtliche Websocket-Aufrufe mit "fehlendes hass oder entry_id" brachen.
+  if (!entry_id) {
+    entry_id = panelConfig?.entry_id;
+  }
+
+  // Legacy verschachtelte Struktur (panel_custom)
+  if (!entry_id) {
+    entry_id = panelConfig?.config?._panel_custom?.config?.entry_id;
+  }
+
+  // Fallback: aus hass.panels suchen
+  if (!entry_id && hass?.panels) {
+    const candidate =
+      hass.panels.ppreader ||
+      hass.panels.pp_reader ||
+      Object.values(hass.panels).find(p => p?.webcomponent_name === 'pp-reader-panel');
+    entry_id =
+      candidate?.config?.entry_id ||
+      candidate?.config?._panel_custom?.config?.entry_id;
+  }
+
+  return entry_id;
+}
+
+// Export für andere Module (Dashboard/Event-Filter)
+export function getEntryId(hass, panelConfig) {
+  return deriveEntryId(hass, panelConfig);
+}
+
+// Dashboard Data
+export async function fetchDashboardDataWS(hass, panelConfig) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(`fetchDashboardDataWS: fehlendes hass oder entry_id (${entry_id})`);
+  }
+  return await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_dashboard_data",
+    entry_id,
+  });
+}
+
+// Accounts
+export async function fetchAccountsWS(hass, panelConfig) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(`fetchAccountsWS: fehlendes hass oder entry_id (${entry_id})`);
+  }
+  return await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_accounts",
+    entry_id,
+  });
+}
+
+// Last file update
+export async function fetchLastFileUpdateWS(hass, panelConfig) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(`fetchLastFileUpdateWS: fehlendes hass oder entry_id (${entry_id})`);
+  }
+  const response = await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_last_file_update",
+    entry_id,
+  });
+  return response?.last_file_update || response || '';
+}
+
+// Portfolios
+export async function fetchPortfoliosWS(hass, panelConfig) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(`fetchPortfoliosWS: fehlendes hass oder entry_id (${entry_id})`);
+  }
+  return await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_portfolio_data",
+    entry_id,
+  });
+}
+
+// Positions (lazy)
+export async function fetchPortfolioPositionsWS(hass, panelConfig, portfolio_uuid) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(`fetchPortfolioPositionsWS: fehlendes hass oder entry_id (${entry_id})`);
+  }
+  if (!portfolio_uuid) {
+    throw new Error("fetchPortfolioPositionsWS: fehlendes portfolio_uuid");
+  }
+  return await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_portfolio_positions",
+    entry_id,
+    portfolio_uuid,
+  });
+}
+
+// Security snapshot for detail tab
+export async function fetchSecuritySnapshotWS(
+  hass,
+  panelConfig,
+  securityUuid,
+) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(
+      `fetchSecuritySnapshotWS: fehlendes hass oder entry_id (${entry_id})`,
+    );
+  }
+  if (!securityUuid) {
+    throw new Error("fetchSecuritySnapshotWS: fehlendes securityUuid");
+  }
+
+  return await hass.connection.sendMessagePromise({
+    type: "pp_reader/get_security_snapshot",
+    entry_id,
+    security_uuid: securityUuid,
+  });
+}
+
+// Historical prices for detail tab charting
+export async function fetchSecurityHistoryWS(
+  hass,
+  panelConfig,
+  securityUuid,
+  options = {},
+) {
+  const entry_id = deriveEntryId(hass, panelConfig);
+  if (!hass || !entry_id) {
+    throw new Error(
+      `fetchSecurityHistoryWS: fehlendes hass oder entry_id (${entry_id})`,
+    );
+  }
+  if (!securityUuid) {
+    throw new Error("fetchSecurityHistoryWS: fehlendes securityUuid");
+  }
+
+  const payload = {
+    type: "pp_reader/get_security_history",
+    entry_id,
+    security_uuid: securityUuid,
+  };
+
+  const { startDate, endDate, start_date: start_date_raw, end_date: end_date_raw } =
+    options || {};
+
+  const resolvedStart = startDate ?? start_date_raw;
+  if (resolvedStart !== undefined && resolvedStart !== null) {
+    payload.start_date = resolvedStart;
+  }
+
+  const resolvedEnd = endDate ?? end_date_raw;
+  if (resolvedEnd !== undefined && resolvedEnd !== null) {
+    payload.end_date = resolvedEnd;
+  }
+
+  return await hass.connection.sendMessagePromise(payload);
+}

--- a/src/data/updateConfigsWS.ts
+++ b/src/data/updateConfigsWS.ts
@@ -1,0 +1,895 @@
+// @ts-nocheck
+
+/**
+ * Live update handlers mirrored from the legacy websocket client.
+ */
+
+import { makeTable } from '../content/elements.js';
+import { sortTableRows } from '../content/elements.js'; // NEU: generische Sortier-Utility
+
+const PENDING_RETRY_INTERVAL = 500;
+const PENDING_MAX_ATTEMPTS = 10;
+const PORTFOLIO_POSITIONS_UPDATED_EVENT = 'pp-reader:portfolio-positions-updated';
+
+function ensurePendingMap() {
+  if (!window.__ppReaderPendingPositions) {
+    window.__ppReaderPendingPositions = new Map();
+  }
+  return window.__ppReaderPendingPositions;
+}
+
+function ensurePendingRetryMeta() {
+  if (!window.__ppReaderPendingRetryMeta) {
+    window.__ppReaderPendingRetryMeta = new Map();
+  }
+  return window.__ppReaderPendingRetryMeta;
+}
+
+function renderPositionsError(error, portfolioUuid) {
+  const safeError = typeof error === 'string' ? error : String(error || 'Unbekannter Fehler');
+  return `<div class="error">${safeError} <button class="retry-pos" data-portfolio="${portfolioUuid}">Erneut laden</button></div>`;
+}
+
+function restoreSortAndInit(containerEl, rootEl, pid) {
+  const table = containerEl.querySelector('table.sortable-positions');
+  if (!table) return;
+
+  const key = containerEl.dataset.sortKey || table.dataset.defaultSort || 'name';
+  const dir = containerEl.dataset.sortDir || table.dataset.defaultDir || 'asc';
+  containerEl.dataset.sortKey = key;
+  containerEl.dataset.sortDir = dir;
+
+  try {
+    sortTableRows(table, key, dir, true);
+  } catch (e) {
+    console.warn('restoreSortAndInit: sortTableRows Fehler:', e);
+  }
+
+  try {
+    if (window.__ppReaderAttachPortfolioPositionsSorting) {
+      window.__ppReaderAttachPortfolioPositionsSorting(rootEl, pid);
+    }
+  } catch (e) {
+    console.warn('restoreSortAndInit: attachPortfolioPositionsSorting Fehler:', e);
+  }
+
+  try {
+    if (window.__ppReaderAttachSecurityDetailListener) {
+      window.__ppReaderAttachSecurityDetailListener(rootEl, pid);
+    }
+  } catch (e) {
+    console.warn('restoreSortAndInit: attachSecurityDetailListener Fehler:', e);
+  }
+}
+
+function applyPortfolioPositionsToDom(root, portfolioUuid, positions, error) {
+  if (!root || !portfolioUuid) {
+    return { applied: false, reason: 'invalid' };
+  }
+
+  const detailsRow = root.querySelector(
+    `.portfolio-table .portfolio-details[data-portfolio="${portfolioUuid}"]`
+  );
+  if (!detailsRow) {
+    return { applied: false, reason: 'missing' };
+  }
+
+  const container = detailsRow.querySelector('.positions-container');
+  if (!container) {
+    return { applied: false, reason: 'missing' };
+  }
+
+  if (detailsRow.classList.contains('hidden')) {
+    return { applied: false, reason: 'hidden' };
+  }
+
+  if (error) {
+    container.innerHTML = renderPositionsError(error, portfolioUuid);
+    return { applied: true };
+  }
+
+  const prevKey = container.dataset.sortKey;
+  const prevDir = container.dataset.sortDir;
+
+  container.innerHTML = renderPositionsTableInline(positions || []);
+
+  if (prevKey) container.dataset.sortKey = prevKey;
+  if (prevDir) container.dataset.sortDir = prevDir;
+
+  restoreSortAndInit(container, root, portfolioUuid);
+  return { applied: true };
+}
+
+export function flushPendingPositions(root, portfolioUuid) {
+  const pendingMap = ensurePendingMap();
+  const pending = pendingMap.get(portfolioUuid);
+  if (!pending) return false;
+
+  const result = applyPortfolioPositionsToDom(
+    root,
+    portfolioUuid,
+    pending.positions,
+    pending.error
+  );
+  if (result.applied) {
+    pendingMap.delete(portfolioUuid);
+  }
+  return result.applied;
+}
+
+export function flushAllPendingPositions(root) {
+  const pendingMap = ensurePendingMap();
+  let appliedAny = false;
+  for (const [portfolioUuid] of pendingMap) {
+    if (flushPendingPositions(root, portfolioUuid)) {
+      appliedAny = true;
+    }
+  }
+  return appliedAny;
+}
+
+function schedulePendingRetry(root, portfolioUuid) {
+  const retryMetaMap = ensurePendingRetryMeta();
+  const meta = retryMetaMap.get(portfolioUuid) || { attempts: 0, timer: null };
+
+  if (meta.timer) {
+    return;
+  }
+
+  meta.timer = setTimeout(() => {
+    meta.timer = null;
+    meta.attempts += 1;
+
+    const success = flushPendingPositions(root, portfolioUuid);
+    if (success || meta.attempts >= PENDING_MAX_ATTEMPTS) {
+      retryMetaMap.delete(portfolioUuid);
+      if (!success) {
+        ensurePendingMap().delete(portfolioUuid);
+      }
+    } else {
+      schedulePendingRetry(root, portfolioUuid);
+    }
+  }, PENDING_RETRY_INTERVAL);
+
+  retryMetaMap.set(portfolioUuid, meta);
+}
+
+/**
+ * Handler für Kontodaten-Updates (Accounts, inkl. FX).
+ * @param {Array} update - Die empfangenen Kontodaten (mit currency_code, orig_balance, balance(EUR)).
+ * @param {HTMLElement} root - Das Root-Element des Dashboards.
+ */
+export function handleAccountUpdate(update, root) {
+  console.log("updateConfigsWS: Kontodaten-Update erhalten:", update);
+  const updatedAccounts = update || [];
+
+  // Tabellen aktualisieren (EUR + FX)
+  updateAccountTable(updatedAccounts, root);
+
+  // Portfolios aus aktueller Tabelle lesen (für Total-Neuberechnung)
+  const portfolioTable = root.querySelector('.portfolio-table table');
+  const portfolios = portfolioTable
+    ? Array.from(portfolioTable.querySelectorAll('tbody tr:not(.footer-row)')).map(row => {
+      // Spalten: Name | position_count | current_value | gain_abs | gain_pct
+      const currentValueCell = row.cells[2];
+      return {
+        current_value: parseFloat(
+          (currentValueCell?.textContent || '')
+            .replace(/\./g, '')
+            .replace(',', '.')
+            .replace(/[^\d.-]/g, '')
+        ) || 0
+      };
+    })
+    : [];
+
+  updateTotalWealth(updatedAccounts, portfolios, root);
+}
+
+/**
+ * Aktualisiert die Tabellen mit den Kontodaten (EUR + FX).
+ * @param {Array} accounts - Alle Kontodaten.
+ * @param {HTMLElement} root - Root-Element.
+ */
+function updateAccountTable(accounts, root) {
+  const eurContainer = root.querySelector('.account-table');
+  const fxContainer = root.querySelector('.fx-account-table');
+
+  const eurAccounts = accounts.filter(a => (a.currency_code || 'EUR') === 'EUR');
+  const fxAccounts = accounts.filter(a => (a.currency_code || 'EUR') !== 'EUR');
+
+  if (eurContainer) {
+    eurContainer.innerHTML = makeTable(eurAccounts, [
+      { key: 'name', label: 'Name' },
+      { key: 'balance', label: 'Kontostand (EUR)', align: 'right' }
+    ], ['balance']);
+  } else {
+    console.warn("updateAccountTable: .account-table nicht gefunden.");
+  }
+
+  if (fxContainer) {
+    fxContainer.innerHTML = makeTable(
+      fxAccounts.map(a => ({
+        ...a,
+        fx_display: `${(a.orig_balance ?? 0).toLocaleString('de-DE', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        })}\u00A0${a.currency_code}`
+      })),
+      [
+        { key: 'name', label: 'Name' },
+        { key: 'fx_display', label: 'Betrag (FX)' },
+        { key: 'balance', label: 'EUR', align: 'right' }
+      ],
+      ['balance']
+    );
+  } else if (fxAccounts.length) {
+    console.warn("updateAccountTable: .fx-account-table nicht gefunden, obwohl FX-Konten vorhanden sind.");
+  }
+}
+
+/**
+ * Handler für Depot-Updates (aggregierte Portfolio-Werte).
+ * Ersetzt die bisherige komplette Tabellen-Neuerstellung durch ein gezieltes Patchen
+ * der vorhandenen expandierbaren Tabelle (gebaut in overview.js).
+ * @param {Array} update - Die empfangenen Depotdaten (uuid, name, current_value, purchase_sum, position_count)
+ * @param {HTMLElement} root - Root-Element.
+ */
+export function handlePortfolioUpdate(update, root) {
+  if (!Array.isArray(update)) {
+    console.warn("handlePortfolioUpdate: Update ist kein Array:", update);
+    return;
+  }
+  try {
+    console.debug("handlePortfolioUpdate: payload=", update);
+  } catch (_) { }
+
+  // Tabelle finden (neuer Selektor unterstützt beide Varianten)
+  const table =
+    root?.querySelector('.portfolio-table table') ||
+    root?.querySelector('table.expandable-portfolio-table');
+  if (!table) {
+    const overviewHost = root?.querySelector('.portfolio-table');
+    const detailViewActive =
+      !overviewHost &&
+      (root?.querySelector('.security-range-selector') ||
+        root?.querySelector('.security-detail-placeholder'));
+
+    if (detailViewActive) {
+      console.debug(
+        "handlePortfolioUpdate: Übersicht nicht aktiv – Update wird später angewendet."
+      );
+    } else {
+      console.warn("handlePortfolioUpdate: Keine Portfolio-Tabelle gefunden.");
+    }
+    return;
+  }
+  const tbody = table.tBodies?.[0];
+  if (!tbody) {
+    console.warn("handlePortfolioUpdate: Kein <tbody> in Tabelle.");
+    return;
+  }
+
+  // Helper Formatierer (lokal oder einfacher Fallback)
+  const formatNumber = (val) => {
+    if (window.Intl) {
+      try {
+        return new Intl.NumberFormat(navigator.language || 'de-DE', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        }).format(val);
+      } catch (_) { }
+    }
+    return (Math.round(val * 100) / 100).toFixed(2).replace('.', ',');
+  };
+
+  // Map: uuid -> Row
+  const rowMap = new Map(
+    Array.from(tbody.querySelectorAll('tr.portfolio-row'))
+      .filter(r => r.dataset && r.dataset.portfolio)
+      .map(r => [r.dataset.portfolio, r])
+  );
+
+  let patched = 0;
+
+  const formatPositionCount = (value) => {
+    const numeric = Number.isFinite(value) ? value : 0;
+    try {
+      return numeric.toLocaleString('de-DE');
+    } catch (_error) {
+      return numeric.toString();
+    }
+  };
+
+  for (const u of update) {
+    if (!u || !u.uuid) continue;
+    const row = rowMap.get(u.uuid);
+    if (!row) continue;
+
+    if (row.cells.length < 3) continue;
+
+    const posCountCell = row.cells[1];
+    const curValCell = row.cells[2];
+    const gainAbsCell = row.cells[3];
+    const gainPctCell = row.cells[4];
+
+    // Normalisierung (Full Sync nutzt value/purchase_sum; Price Events current_value/purchase_sum)
+    const posCount = Number(u.position_count ?? u.count ?? 0);
+    const curVal = Number(u.current_value ?? u.value ?? 0);
+    const purchase = Number(u.purchase_sum ?? u.purchaseSum ?? 0);
+
+    const gainAbs = curVal - purchase;
+    const gainPct = purchase > 0 ? (gainAbs / purchase) * 100 : 0;
+
+    const oldCur = parseNumLoose(curValCell.textContent);
+    const oldCnt = parseNumLoose(posCountCell.textContent);
+
+    if (oldCnt !== posCount) {
+      posCountCell.textContent = formatPositionCount(posCount);
+    }
+    if (Math.abs(oldCur - curVal) >= 0.005) {
+      curValCell.textContent = formatNumber(curVal) + ' €';
+      row.classList.add('flash-update');
+      setTimeout(() => row.classList.remove('flash-update'), 800);
+    }
+    if (gainAbsCell) {
+      gainAbsCell.innerHTML = formatGain(gainAbs);
+      gainAbsCell.dataset.gainPct = Number.isFinite(gainPct)
+        ? `${formatNumber(gainPct)} %`
+        : '—';
+      gainAbsCell.dataset.gainSign = Number.isFinite(gainPct)
+        ? (gainPct > 0 ? 'positive' : gainPct < 0 ? 'negative' : 'neutral')
+        : 'neutral';
+    }
+    if (gainPctCell) {
+      gainPctCell.innerHTML = formatGainPct(gainPct);
+    }
+
+    row.dataset.positionCount = String(posCount);
+    row.dataset.currentValue = String(curVal);
+    row.dataset.purchaseSum = String(purchase);
+    row.dataset.gainAbs = String(gainAbs);
+    row.dataset.gainPct = String(gainPct);
+
+    patched++;
+
+  }
+
+  if (patched === 0) {
+    console.debug("handlePortfolioUpdate: Keine passenden Zeilen gefunden / keine Änderungen.");
+  } else {
+    console.debug(`handlePortfolioUpdate: ${patched} Zeile(n) gepatcht.`);
+  }
+
+  try {
+    updatePortfolioFooter(table);
+  } catch (e) {
+    console.warn("handlePortfolioUpdate: Fehler bei Summen-Neuberechnung:", e);
+  }
+
+  // Total-Wealth neu berechnen (Accounts + Portfolios)
+  try {
+    const findTable = (...selectors) => {
+      for (const selector of selectors) {
+        if (!selector) continue;
+        const tableEl = root?.querySelector(selector);
+        if (tableEl) return tableEl;
+      }
+      return null;
+    };
+
+    const eurTable = findTable(
+      '.account-table table',
+      '.accounts-eur-table table',
+      '.accounts-table table'
+    );
+    const fxTable = findTable(
+      '.fx-account-table table',
+      '.accounts-fx-table table'
+    );
+
+    const extractAccounts = (tbl, isFx) => {
+      if (!tbl) return [];
+      const accountRows = tbl.querySelectorAll('tbody tr.account-row');
+      const rows = accountRows.length
+        ? Array.from(accountRows)
+        : Array.from(tbl.querySelectorAll('tbody tr:not(.footer-row)'));
+
+      return rows.map(r => {
+        const cell = isFx ? r.cells[2] : r.cells[1];
+        return { balance: parseNumLoose(cell?.textContent) };
+      });
+    };
+    const accounts = [
+      ...extractAccounts(eurTable, false),
+      ...extractAccounts(fxTable, true),
+    ];
+
+    const portfolioDomValues = Array.from(
+      table.querySelectorAll('tbody tr.portfolio-row')
+    ).map(r => {
+      const cv = parseNumLoose(r.cells[2]?.textContent);
+      const gain = parseNumLoose(r.cells[3]?.textContent);
+      const ps = cv - gain;
+      return { current_value: cv, purchase_sum: ps };
+    });
+
+    if (typeof updateTotalWealth === 'function') {
+      updateTotalWealth(accounts, portfolioDomValues, root);
+    }
+  } catch (e) {
+    console.warn("handlePortfolioUpdate: Fehler bei Total-Neuberechnung:", e);
+  }
+}
+
+/**
+ * NEU: Handler für Einzel-Positions-Updates (Event: portfolio_positions).
+ * @param {{portfolio_uuid: string, positions: Array}} update
+ * @param {HTMLElement} root
+ */
+function normalizePortfolioUuid(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const direct = payload.portfolio_uuid;
+  if (typeof direct === 'string' && direct) {
+    return direct;
+  }
+  const camelCase = payload.portfolioUuid;
+  if (typeof camelCase === 'string' && camelCase) {
+    return camelCase;
+  }
+  return null;
+}
+
+function processPortfolioPositionsUpdate(update, root) {
+  const portfolioUuid = normalizePortfolioUuid(update);
+  if (!portfolioUuid) {
+    console.warn("handlePortfolioPositionsUpdate: Ungültiges Update:", update);
+    return false;
+  }
+
+  const error = update?.error;
+  const positions = Array.isArray(update?.positions) ? update.positions : [];
+
+  // Positions-Cache aktualisieren (Lazy-Load bleibt bestehen)
+  try {
+    const cache = window.__ppReaderPortfolioPositionsCache;
+    if (cache && typeof cache.set === 'function' && !error) {
+      cache.set(portfolioUuid, positions);
+    }
+  } catch (e) {
+    console.warn("handlePortfolioPositionsUpdate: Positions-Cache konnte nicht aktualisiert werden:", e);
+  }
+
+  const result = applyPortfolioPositionsToDom(root, portfolioUuid, positions, error);
+  const pendingMap = ensurePendingMap();
+
+  if (result.applied) {
+    pendingMap.delete(portfolioUuid);
+  } else {
+    pendingMap.set(portfolioUuid, { positions, error });
+    if (result.reason !== 'hidden') {
+      schedulePendingRetry(root, portfolioUuid);
+    }
+  }
+
+  if (!error && positions.length > 0) {
+    const securityUuids = Array.from(
+      new Set(
+        positions
+          .map((pos) => pos?.security_uuid)
+          .filter((uuid) => typeof uuid === 'string' && uuid.length > 0),
+      ),
+    );
+
+    if (securityUuids.length && typeof window !== 'undefined') {
+      try {
+        window.dispatchEvent(
+          new CustomEvent(PORTFOLIO_POSITIONS_UPDATED_EVENT, {
+            detail: {
+              portfolioUuid,
+              securityUuids,
+            },
+          }),
+        );
+      } catch (dispatchError) {
+        console.warn(
+          'handlePortfolioPositionsUpdate: Dispatch des Portfolio-Events fehlgeschlagen',
+          dispatchError,
+        );
+      }
+    }
+  }
+
+  return true;
+}
+
+export function handlePortfolioPositionsUpdate(update, root) {
+  if (Array.isArray(update)) {
+    let handled = false;
+    for (const item of update) {
+      if (processPortfolioPositionsUpdate(item, root)) {
+        handled = true;
+      }
+    }
+    if (!handled && update.length) {
+      console.warn("handlePortfolioPositionsUpdate: Kein gültiges Element im Array:", update);
+    }
+    return;
+  }
+
+  processPortfolioPositionsUpdate(update, root);
+}
+
+/* ------------------ Hilfsfunktionen (lokal) ------------------ */
+
+function renderPositionsTableInline(positions) {
+  // Konsistenz Push vs Lazy:
+  try {
+    if (window.__ppReaderRenderPositionsTable) {
+      return window.__ppReaderRenderPositionsTable(positions);
+    }
+  } catch (_) { }
+
+  if (!positions || !positions.length) {
+    return '<div class="no-positions">Keine Positionen vorhanden.</div>';
+  }
+  const rows = positions.map(p => ({
+    name: p.name,
+    current_holdings: p.current_holdings,
+    purchase_value: p.purchase_value,
+    current_value: p.current_value,
+    gain_abs: p.gain_abs,
+    gain_pct: p.gain_pct
+  }));
+
+  // Basis HTML
+  const raw = makeTable(
+    rows,
+    [
+      { key: 'name', label: 'Wertpapier' },
+      { key: 'current_holdings', label: 'Bestand', align: 'right' },
+      { key: 'purchase_value', label: 'Kaufwert', align: 'right' },
+      { key: 'current_value', label: 'Aktueller Wert', align: 'right' },
+      { key: 'gain_abs', label: '+/-', align: 'right' },
+      { key: 'gain_pct', label: '%', align: 'right' }
+    ],
+    ['purchase_value', 'current_value', 'gain_abs']
+  );
+
+  // Sortier-Metadaten wie in overview.js renderPositionsTable injizieren
+  try {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = raw.trim();
+    const table = tpl.content.querySelector('table');
+    if (table) {
+      table.classList.add('sortable-positions');
+      const ths = table.querySelectorAll('thead th');
+      const colKeys = ['name', 'current_holdings', 'purchase_value', 'current_value', 'gain_abs', 'gain_pct'];
+      ths.forEach((th, i) => {
+        const key = colKeys[i];
+        if (!key) return;
+        th.setAttribute('data-sort-key', key);
+        th.classList.add('sortable-col');
+      });
+      const bodyRows = table.querySelectorAll('tbody tr');
+      bodyRows.forEach((tr, idx) => {
+        if (tr.classList.contains('footer-row')) {
+          return;
+        }
+        const pos = positions[idx];
+        if (pos?.security_uuid) {
+          tr.dataset.security = pos.security_uuid;
+        }
+        tr.classList.add('position-row');
+      });
+      table.dataset.defaultSort = 'name';
+      table.dataset.defaultDir = 'asc';
+      if (window.__ppReaderApplyGainPctMetadata) {
+        try {
+          window.__ppReaderApplyGainPctMetadata(table);
+        } catch (err) {
+          console.warn('renderPositionsTableInline: applyGainPctMetadata failed', err);
+        }
+      } else {
+        const rows = table.querySelectorAll('tbody tr');
+        rows.forEach(row => {
+          const gainCell = row.cells?.[4];
+          const pctCell = row.cells?.[5];
+          if (!gainCell || !pctCell) return;
+          const pctText = (pctCell.textContent || '').trim() || '—';
+          let pctSign = 'neutral';
+          if (pctCell.querySelector('.positive')) {
+            pctSign = 'positive';
+          } else if (pctCell.querySelector('.negative')) {
+            pctSign = 'negative';
+          }
+          gainCell.dataset.gainPct = pctText;
+          gainCell.dataset.gainSign = pctSign;
+        });
+      }
+      return table.outerHTML;
+    }
+  } catch (e) {
+    console.warn("renderPositionsTableInline: Sortier-Metadaten Injection fehlgeschlagen:", e);
+  }
+  return raw;
+}
+
+if (!window.__ppReaderFlushPendingPositions) {
+  window.__ppReaderFlushPendingPositions = (root, portfolioUuid) =>
+    flushPendingPositions(root, portfolioUuid);
+}
+
+if (!window.__ppReaderFlushAllPendingPositions) {
+  window.__ppReaderFlushAllPendingPositions = (root) => flushAllPendingPositions(root);
+}
+
+function updatePortfolioFooter(table) {
+  if (!table) return;
+  try {
+    const helper = window.__ppReaderUpdatePortfolioFooter;
+    if (typeof helper === 'function') {
+      helper(table);
+      return;
+    }
+  } catch (err) {
+    console.warn("updatePortfolioFooter: global Helper schlug fehl:", err);
+  }
+
+  const rows = Array.from(table.querySelectorAll('tbody tr.portfolio-row'));
+  let sumCurrent = 0;
+  let sumGainAbs = 0;
+  let sumPurchase = 0;
+  let sumPositions = 0;
+
+  rows.forEach(r => {
+    const datasetCount = Number(r.dataset?.positionCount);
+    const posCount = Number.isFinite(datasetCount)
+      ? datasetCount
+      : parseInt((r.cells[1]?.textContent || '').replace(/\./g, ''), 10) || 0;
+
+    const datasetCurrent = Number(r.dataset?.currentValue);
+    const currentValue = Number.isFinite(datasetCurrent)
+      ? datasetCurrent
+      : parseNumLoose(r.cells[2]?.textContent);
+
+    const datasetGain = Number(r.dataset?.gainAbs);
+    const gainAbs = Number.isFinite(datasetGain)
+      ? datasetGain
+      : parseNumLoose(r.cells[3]?.textContent);
+
+    const datasetPurchase = Number(r.dataset?.purchaseSum);
+    const purchase = Number.isFinite(datasetPurchase)
+      ? datasetPurchase
+      : (currentValue - gainAbs);
+
+    sumPositions += posCount;
+    sumCurrent += currentValue;
+    sumGainAbs += gainAbs;
+    sumPurchase += purchase;
+  });
+
+  if (sumPurchase <= 0) {
+    sumPurchase = sumCurrent - sumGainAbs;
+  }
+  const sumGainPct = sumPurchase > 0 ? (sumGainAbs / sumPurchase) * 100 : 0;
+
+  let footer = table.querySelector('tr.footer-row');
+  if (!footer) {
+    footer = document.createElement('tr');
+    footer.className = 'footer-row';
+    table.querySelector('tbody')?.appendChild(footer);
+  }
+  const sumPositionsDisplay = Math.round(sumPositions).toLocaleString('de-DE');
+
+  footer.innerHTML = `
+    <td>Summe</td>
+    <td class="align-right">${sumPositionsDisplay}</td>
+    <td class="align-right">${formatNumber(sumCurrent)}&nbsp;€</td>
+    <td class="align-right">${formatGain(sumGainAbs)}</td>
+    <td class="align-right">${formatGainPct(sumGainPct)}</td>
+  `;
+  const footerGainAbsCell = footer.cells?.[3];
+  if (footerGainAbsCell) {
+    footerGainAbsCell.dataset.gainPct = Number.isFinite(sumGainPct)
+      ? `${formatNumber(sumGainPct)} %`
+      : '—';
+    footerGainAbsCell.dataset.gainSign = Number.isFinite(sumGainPct)
+      ? (sumGainPct > 0 ? 'positive' : sumGainPct < 0 ? 'negative' : 'neutral')
+      : 'neutral';
+  }
+  footer.dataset.positionCount = String(Math.round(sumPositions));
+  footer.dataset.currentValue = String(sumCurrent);
+  footer.dataset.purchaseSum = String(sumPurchase);
+  footer.dataset.gainAbs = String(sumGainAbs);
+  footer.dataset.gainPct = String(sumGainPct);
+}
+
+function parseLocaleNumber(txt = '') {
+  if (!txt) return 0;
+  return parseFloat(
+    txt
+      .replace(/[^0-9,.\-]/g, '')
+      .replace(/\./g, '')
+      .replace(',', '.')
+  ) || 0;
+}
+
+function formatNumber(v) {
+  return (isNaN(v) ? 0 : v).toLocaleString('de-DE', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}
+function formatGain(v) {
+  const cls = v >= 0 ? 'positive' : 'negative';
+  return `<span class="${cls}">${formatNumber(v)}&nbsp;€</span>`;
+}
+function formatGainPct(v) {
+  const cls = v >= 0 ? 'positive' : 'negative';
+  return `<span class="${cls}">${formatNumber(v)}&nbsp;%</span>`;
+}
+
+function updateTotalWealth(accounts, portfolios, root) {
+  const targetRoot = root || document;
+
+  const accountSum = (Array.isArray(accounts) ? accounts : []).reduce((acc, entry) => {
+    const value = entry != null && typeof entry === 'object'
+      ? entry.balance ?? entry.current_value ?? entry.value ?? 0
+      : entry;
+    const numeric = Number(value);
+    return acc + (Number.isFinite(numeric) ? numeric : 0);
+  }, 0);
+
+  const portfolioSum = (Array.isArray(portfolios) ? portfolios : []).reduce((acc, entry) => {
+    const value = entry != null && typeof entry === 'object'
+      ? entry.current_value ?? entry.value ?? 0
+      : entry;
+    const numeric = Number(value);
+    return acc + (Number.isFinite(numeric) ? numeric : 0);
+  }, 0);
+
+  const totalWealth = accountSum + portfolioSum;
+
+  const headerMeta = targetRoot?.querySelector('#headerMeta');
+  if (!headerMeta) {
+    console.warn('updateTotalWealth: #headerMeta nicht gefunden.');
+    return;
+  }
+
+  const valueElement = headerMeta.querySelector('strong') || headerMeta.querySelector('.total-wealth-value');
+  if (valueElement) {
+    valueElement.textContent = `${formatNumber(totalWealth)}\u00A0€`;
+  } else {
+    headerMeta.textContent = `💰 Gesamtvermögen: ${formatNumber(totalWealth)}\u00A0€`;
+  }
+
+  headerMeta.dataset.totalWealthEur = String(totalWealth);
+}
+
+/**
+ * HINWEIS (2025-09):
+ * Die frühere Funktion updatePortfolioTable (vollständiger Neuaufbau der Depot-Tabelle)
+ * wurde durch inkrementelles Patchen via handlePortfolioUpdate + Lazy-Load der Positions-
+ * daten ersetzt. Alte Implementierung entfernt, um doppelte Logik und Render-Flashes
+ * zu vermeiden.
+ *
+ * Falls noch Referenzen auf updatePortfolioTable existieren, bitte auf handlePortfolioUpdate
+ * umstellen. (dashboard.js ruft bereits nur noch _doRender -> handlePortfolioUpdate auf.)
+ */
+// Entfernte Legacy-Funktion:
+// function updatePortfolioTable(...) { /* veraltet, entfernt */ }
+
+// Helper: Erzeuge (Portfolio-Hauptzeile + Detailzeile) HTML-Strings
+function createPortfolioRowHtml(p, expanded = false) {
+  const detailId = `portfolio-details-${p.uuid}`;
+  const toggleClass = expanded ? 'portfolio-toggle expanded' : 'portfolio-toggle';
+  return {
+    main: `<tr class="portfolio-row" data-portfolio="${p.uuid}">
+      <td>
+        <button type="button"
+                class="${toggleClass}"
+                data-portfolio="${p.uuid}"
+                aria-expanded="${expanded ? 'true' : 'false'}"
+                aria-controls="${detailId}">
+          <span class="caret">${expanded ? '▼' : '▶'}</span>
+          <span class="portfolio-name">${p.name}</span>
+        </button>
+      </td>
+      <td class="align-right">${(p.position_count ?? 0).toLocaleString('de-DE')}</td>
+      <td class="align-right">${formatNumber(p.current_value)}&nbsp;€</td>
+      <td class="align-right">${formatGain(p.current_value - p.purchase_sum)}</td>
+      <td class="align-right">${formatGainPct(p.purchase_sum > 0 ? ((p.current_value - p.purchase_sum) / p.purchase_sum) * 100 : 0)}</td>
+    </tr>`,
+    detail: `<tr class="portfolio-details hidden"
+                 data-portfolio="${p.uuid}"
+                 id="${detailId}"
+                 role="region"
+                 aria-label="Positionen für ${p.name}">
+        <td colspan="5">
+          <div class="positions-container"></div>
+        </td>
+      </tr>`
+  };
+}
+
+// ==== Last File Update Handler (canonical) ====
+// (Ändere zu export function, damit unten kein Sammel-Export nötig ist)
+export function handleLastFileUpdate(update, root) {
+  const value = typeof update === 'string'
+    ? update
+    : (update && update.last_file_update) || '';
+
+  if (!root) {
+    console.warn("handleLastFileUpdate: root fehlt");
+    return;
+  }
+
+  // Bevorzugt Footer-Karte, sonst erste passende Stelle
+  let el = root.querySelector('.footer-card .last-file-update') ||
+    root.querySelector('.last-file-update');
+
+  if (!el) {
+    // Fallback: existierende Meta-Hosts durchsuchen
+    const metaHost =
+      root.querySelector('.footer-card .meta') ||
+      root.querySelector('#headerMeta') ||
+      root.querySelector('.header-card .meta') ||
+      root.querySelector('.header-card');
+    if (!metaHost) {
+      console.warn("handleLastFileUpdate: Kein Einfügepunkt gefunden.");
+      return;
+    }
+    el = document.createElement('div');
+    el.className = 'last-file-update';
+    metaHost.appendChild(el);
+  }
+
+  // Format abhängig vom Ort (Footer behält <strong>)
+  if (el.closest('.footer-card')) {
+    el.innerHTML = value
+      ? `📂 Letzte Aktualisierung der Datei: <strong>${value}</strong>`
+      : `📂 Letzte Aktualisierung der Datei: <strong>Unbekannt</strong>`;
+  } else {
+    // Header/Meta-Version (schlichter Text)
+    el.textContent = value
+      ? `📂 Letzte Aktualisierung: ${value}`
+      : '📂 Letzte Aktualisierung: Unbekannt';
+  }
+}
+/// END handleLastFileUpdate (canonical)
+
+/**
+ * NEUER HELPER (Änderung 8):
+ * Re-applied die gespeicherte Sortierung einer Positions-Tabelle.
+ * Liest container.dataset.sortKey / sortDir oder Default-Werte vom <table>.
+ * Nutzt sortTableRows(..., true) für Positions-Mapping.
+ * @param {HTMLElement} containerEl .positions-container
+ */
+export function reapplyPositionsSort(containerEl) {
+  if (!containerEl) return;
+  const table = containerEl.querySelector('table.sortable-positions');
+  if (!table) return;
+  const key = containerEl.dataset.sortKey || table.dataset.defaultSort || 'name';
+  const dir = containerEl.dataset.sortDir || table.dataset.defaultDir || 'asc';
+  // Persistiere (falls erstmalig)
+  containerEl.dataset.sortKey = key;
+  containerEl.dataset.sortDir = dir;
+  sortTableRows(table, key, dir, true);
+}
+window.__ppReaderReapplyPositionsSort = reapplyPositionsSort; // Optional global für Lazy-Load-Code
+
+// === Globale / modulweite Utilities ===
+function parseNumLoose(txt) {
+  if (txt == null) return 0;
+  return parseFloat(
+    String(txt)
+      .replace(/\u00A0/g, ' ')
+      .replace(/[€%]/g, '')
+      .replace(/\./g, '')
+      .replace(',', '.')
+      .replace(/[^\d.-]/g, '')
+  ) || 0;
+}

--- a/src/interaction/tab_control.ts
+++ b/src/interaction/tab_control.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck
+
+/**
+ * Swipe and tab interaction helpers mirrored from the legacy UI.
+ */
+
+/**
+ * Fügt einem Element Swipe- und Maus-Events hinzu, um zwischen Tabs zu navigieren.
+ * @param {HTMLElement} element - Das Element, das die Events erhalten soll.
+ * @param {Function} onSwipeLeft - Callback für Swipe/Klick nach links (nächster Tab).
+ * @param {Function} onSwipeRight - Callback für Swipe/Klick nach rechts (vorheriger Tab).
+ */
+export function addSwipeEvents(element, onSwipeLeft, onSwipeRight) {
+  let startX = null;
+
+  // Touch-Events für Mobilgeräte
+  element.addEventListener(
+    'touchstart',
+    e => {
+      if (e.touches.length === 1) {
+        startX = e.touches[0].clientX;
+      }
+    },
+    { passive: true } // Passive Listener für bessere Performance
+  );
+
+  element.addEventListener(
+    'touchend',
+    e => {
+      if (startX === null) return;
+      const deltaX = e.changedTouches[0].clientX - startX;
+      if (deltaX < -50) {
+        onSwipeLeft();
+      } else if (deltaX > 50) {
+        onSwipeRight();
+      }
+      startX = null;
+    },
+    { passive: true } // Passive Listener für bessere Performance
+  );
+
+  // Maus-Events für Desktop
+  element.addEventListener(
+    'mousedown',
+    e => {
+      startX = e.clientX;
+    },
+    { passive: true } // Passive Listener für bessere Performance
+  );
+
+  element.addEventListener(
+    'mouseup',
+    e => {
+      if (startX === null) return;
+      const deltaX = e.clientX - startX;
+      if (deltaX < -50) {
+        onSwipeLeft();
+      } else if (deltaX > 50) {
+        onSwipeRight();
+      }
+      startX = null;
+    },
+    { passive: true } // Passive Listener für bessere Performance
+  );
+}
+
+/**
+ * Optional: Funktion zum direkten Wechseln zu einem Tab per Index.
+ * @param {number} targetIndex - Der Index des gewünschten Tabs.
+ * @param {Function} onTabChange - Callback, der beim Wechsel aufgerufen wird.
+ */
+export function goToTab(targetIndex, onTabChange) {
+  if (typeof onTabChange === 'function') {
+    onTabChange(targetIndex);
+  }
+}

--- a/src/tabs/overview.ts
+++ b/src/tabs/overview.ts
@@ -1,0 +1,1085 @@
+// @ts-nocheck
+
+/**
+ * Overview tab renderer copied for the TypeScript source tree.
+ */
+
+import { createHeaderCard, makeTable, formatNumber, formatGain, formatGainPct, formatValue } from '../content/elements.js';
+import { openSecurityDetail } from '../dashboard.module.js';
+import { fetchAccountsWS, fetchLastFileUpdateWS, fetchPortfoliosWS, fetchPortfolioPositionsWS } from '../data/api.js';
+import { flushPendingPositions, flushAllPendingPositions } from '../data/updateConfigsWS.js';
+
+// === Modul-weiter State für Expand/Collapse & Lazy Load ===
+// On-Demand Aggregation liefert frische Portfolio-Werte; nur Positionen bleiben Lazy-Loaded.
+let _hassRef = null;
+let _panelConfigRef = null;
+const portfolioPositionsCache = new Map();      // portfolio_uuid -> positions[]
+
+// --- Security-Aggregation für Detail-Ansicht ---
+const HOLDINGS_PRECISION = 1e6;
+
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function roundCurrency(value) {
+  const finite = toFiniteNumber(value);
+  return Math.round(finite * 100) / 100;
+}
+
+function roundHoldings(value) {
+  const finite = toFiniteNumber(value);
+  return Math.round(finite * HOLDINGS_PRECISION) / HOLDINGS_PRECISION;
+}
+
+function collectSecurityPositions(securityUuid) {
+  if (!securityUuid) {
+    return [];
+  }
+
+  const matches = [];
+  for (const positions of portfolioPositionsCache.values()) {
+    if (!Array.isArray(positions) || positions.length === 0) {
+      continue;
+    }
+    for (const pos of positions) {
+      if (pos && pos.security_uuid === securityUuid) {
+        matches.push(pos);
+      }
+    }
+  }
+  return matches;
+}
+
+export function getSecurityPositionsFromCache(securityUuid) {
+  const positions = collectSecurityPositions(securityUuid);
+  if (!positions.length) {
+    return [];
+  }
+  return positions.map((pos) => ({ ...pos }));
+}
+
+export function getSecuritySnapshotFromCache(securityUuid) {
+  const positions = collectSecurityPositions(securityUuid);
+  if (!positions.length) {
+    return null;
+  }
+
+  let name = '';
+  let totalHoldings = 0;
+  let totalPurchaseValue = 0;
+  let totalCurrentValue = 0;
+
+  for (const pos of positions) {
+    if (!name && pos?.name) {
+      name = pos.name;
+    }
+    totalHoldings += toFiniteNumber(pos?.current_holdings);
+    totalPurchaseValue += toFiniteNumber(pos?.purchase_value);
+    totalCurrentValue += toFiniteNumber(pos?.current_value);
+  }
+
+  const gainAbs = totalCurrentValue - totalPurchaseValue;
+  const gainPct = totalPurchaseValue > 0
+    ? (gainAbs / totalPurchaseValue) * 100
+    : 0;
+  const lastPriceEur = totalHoldings > 0 ? totalCurrentValue / totalHoldings : null;
+
+  return {
+    security_uuid: securityUuid,
+    name,
+    total_holdings: roundHoldings(totalHoldings),
+    purchase_value_eur: roundCurrency(totalPurchaseValue),
+    current_value_eur: roundCurrency(totalCurrentValue),
+    gain_abs_eur: roundCurrency(gainAbs),
+    gain_pct: Math.round(gainPct * 100) / 100,
+    last_price_eur: lastPriceEur != null ? roundCurrency(lastPriceEur) : null,
+    source: 'cache',
+  };
+}
+
+// Global für Push-Handler (Events); hält ausschließlich Positionsdaten für Lazy-Loads
+portfolioPositionsCache.getSecuritySnapshot = getSecuritySnapshotFromCache;
+portfolioPositionsCache.getSecurityPositions = getSecurityPositionsFromCache;
+
+window.__ppReaderPortfolioPositionsCache = portfolioPositionsCache;
+if (!window.__ppReaderGetSecuritySnapshotFromCache) {
+  window.__ppReaderGetSecuritySnapshotFromCache = getSecuritySnapshotFromCache;
+}
+if (!window.__ppReaderGetSecurityPositionsFromCache) {
+  window.__ppReaderGetSecurityPositionsFromCache = getSecurityPositionsFromCache;
+}
+const expandedPortfolios = new Set();           // gemerkte geöffnete Depots (persistiert über Re-Renders)
+
+// ENTFERNT: Globaler document-Listener (Section 6 Hardening)
+// Stattdessen scoped Listener über attachPortfolioToggleHandler(root)
+
+// Rendert die Positions-Tabelle für ein Depot
+function applyGainPctMetadata(tableEl) {
+  if (!tableEl) {
+    return;
+  }
+  const bodyRows = tableEl.querySelectorAll('tbody tr');
+  bodyRows.forEach(row => {
+    const gainAbsCell = row.cells?.[4];
+    const gainPctCell = row.cells?.[5];
+    if (!gainAbsCell || !gainPctCell) {
+      return;
+    }
+    const pctText = (gainPctCell.textContent || '').trim() || '—';
+    let pctSign = 'neutral';
+    if (gainPctCell.querySelector('.positive')) {
+      pctSign = 'positive';
+    } else if (gainPctCell.querySelector('.negative')) {
+      pctSign = 'negative';
+    }
+    gainAbsCell.dataset.gainPct = pctText;
+    gainAbsCell.dataset.gainSign = pctSign;
+  });
+}
+
+if (!window.__ppReaderApplyGainPctMetadata) {
+  window.__ppReaderApplyGainPctMetadata = (tableEl) => applyGainPctMetadata(tableEl);
+}
+
+function renderPositionsTable(positions) {
+  if (!positions || !positions.length) {
+    return '<div class="no-positions">Keine Positionen vorhanden.</div>';
+  }
+  // Mapping für makeTable
+  const cols = [
+    { key: 'name', label: 'Wertpapier' },
+    { key: 'current_holdings', label: 'Bestand', align: 'right' },
+    { key: 'purchase_value', label: 'Kaufwert', align: 'right' },
+    { key: 'current_value', label: 'Aktueller Wert', align: 'right' },
+    { key: 'gain_abs', label: '+/-', align: 'right' },
+    { key: 'gain_pct', label: '%', align: 'right' }
+  ];
+  const rows = positions.map(p => ({
+    name: p.name,
+    current_holdings: p.current_holdings,
+    purchase_value: p.purchase_value,
+    current_value: p.current_value,
+    gain_abs: p.gain_abs,
+    gain_pct: p.gain_pct
+  }));
+
+  // Basis-HTML über makeTable erzeugen
+  const raw = makeTable(rows, cols, ['purchase_value', 'current_value', 'gain_abs']);
+
+  // Header um data-sort-key ergänzen + sortable Klasse setzen
+  try {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = raw.trim();
+    const table = tpl.content.querySelector('table');
+    if (table) {
+      table.classList.add('sortable-positions');
+      const ths = table.querySelectorAll('thead th');
+      cols.forEach((c, i) => {
+        const th = ths[i];
+        if (th) {
+          th.setAttribute('data-sort-key', c.key);
+          th.classList.add('sortable-col');
+        }
+      });
+      const bodyRows = table.querySelectorAll('tbody tr');
+      bodyRows.forEach((tr, idx) => {
+        if (tr.classList.contains('footer-row')) {
+          return;
+        }
+        const pos = positions[idx];
+        if (!pos) {
+          return;
+        }
+        if (pos.security_uuid) {
+          tr.dataset.security = pos.security_uuid;
+        }
+        tr.classList.add('position-row');
+      });
+      // Default-Sortierung (nach Name asc) – bereits durch SQL geliefert, aber markieren
+      table.dataset.defaultSort = 'name';
+      table.dataset.defaultDir = 'asc';
+      applyGainPctMetadata(table);
+      return table.outerHTML;
+    }
+  } catch (e) {
+    // Fallback: unverändertes Markup
+    console.warn("renderPositionsTable: Konnte Sortier-Metadaten nicht injizieren:", e);
+  }
+  return raw;
+}
+
+// NEU: Export / Global bereitstellen für Push-Handler (Konsistenz Push vs Lazy)
+export function renderPortfolioPositions(positions) {
+  return renderPositionsTable(positions);
+}
+window.__ppReaderRenderPositionsTable = renderPositionsTable;
+
+function attachSecurityDetailDelegation(root, portfolioUuid) {
+  if (!root || !portfolioUuid) return;
+  const detailsRow = root.querySelector(`.portfolio-details[data-portfolio="${portfolioUuid}"]`);
+  if (!detailsRow) return;
+  const container = detailsRow.querySelector('.positions-container');
+  if (!container || container.__ppReaderSecurityClickBound) return;
+
+  container.__ppReaderSecurityClickBound = true;
+
+  container.addEventListener('click', (event) => {
+    const interactive = event.target.closest('button, a');
+    if (interactive && container.contains(interactive)) {
+      return;
+    }
+
+    const row = event.target.closest('tr[data-security]');
+    if (!row || !container.contains(row)) {
+      return;
+    }
+
+    const securityUuid = row.getAttribute('data-security');
+    if (!securityUuid) {
+      return;
+    }
+
+    try {
+      const opened = openSecurityDetail(securityUuid);
+      if (!opened) {
+        console.warn('attachSecurityDetailDelegation: Detail-Tab konnte nicht geöffnet werden für', securityUuid);
+      }
+    } catch (err) {
+      console.error('attachSecurityDetailDelegation: Fehler beim Öffnen des Detail-Tabs', err);
+    }
+  });
+}
+
+export function attachSecurityDetailListener(root, portfolioUuid) {
+  attachSecurityDetailDelegation(root, portfolioUuid);
+}
+
+if (!window.__ppReaderAttachSecurityDetailListener) {
+  window.__ppReaderAttachSecurityDetailListener = attachSecurityDetailListener;
+}
+
+// (1) Entferne evtl. doppelte frühere Definitionen von buildExpandablePortfolioTable – nur diese Version behalten
+function buildExpandablePortfolioTable(depots) {
+  console.debug("buildExpandablePortfolioTable: render", depots.length, "portfolios");
+  const escapeAttribute = (value) => {
+    if (value == null) {
+      return '';
+    }
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  };
+
+  let html = '<table class="expandable-portfolio-table"><thead><tr>';
+  const cols = [
+    { key: 'name', label: 'Name' },
+    { key: 'position_count', label: 'Anzahl Positionen', align: 'right' },
+    { key: 'current_value', label: 'Aktueller Wert', align: 'right' },
+    { key: 'gain_abs', label: 'Gesamt +/-', align: 'right' },
+    { key: 'gain_pct', label: '%', align: 'right' }
+  ];
+  cols.forEach(c => {
+    const align = c.align === 'right' ? ' class="align-right"' : '';
+    html += `<th${align}>${c.label}</th>`;
+  });
+  html += '</tr></thead><tbody>';
+
+  depots.forEach(d => {
+    if (!d || !d.uuid) return;
+    const positionCount = Number.isFinite(d.position_count) ? d.position_count : 0;
+    const purchaseSum = Number.isFinite(d.purchase_sum) ? d.purchase_sum : 0;
+    const hasValue = d.hasValue !== false;
+    const currentValue = hasValue && Number.isFinite(d.current_value) ? d.current_value : null;
+    const gainAbs = hasValue && Number.isFinite(d.gain_abs)
+      ? d.gain_abs
+      : (hasValue && Number.isFinite(d.current_value) ? d.current_value - purchaseSum : null);
+    const gainPct = hasValue && Number.isFinite(d.gain_pct)
+      ? d.gain_pct
+      : (hasValue && purchaseSum > 0 && Number.isFinite(currentValue)
+        ? ((currentValue - purchaseSum) / purchaseSum) * 100
+        : null);
+
+    const expanded = expandedPortfolios.has(d.uuid);
+    const toggleClass = expanded ? 'portfolio-toggle expanded' : 'portfolio-toggle';
+    const detailId = `portfolio-details-${d.uuid}`;
+    const rowData = {
+      fx_unavailable: !hasValue,
+      current_value: currentValue,
+      gain_abs: gainAbs,
+      gain_pct: gainPct
+    };
+    const valueContext = { hasValue };
+    const currentValueCell = formatValue('current_value', rowData.current_value, rowData, valueContext);
+    const gainAbsCell = formatValue('gain_abs', rowData.gain_abs, rowData, valueContext);
+    const gainPctCell = formatValue('gain_pct', rowData.gain_pct, rowData, valueContext);
+
+    const gainPctLabel = hasValue && Number.isFinite(gainPct)
+      ? `${formatNumber(gainPct)} %`
+      : '';
+    const gainPctSign = hasValue && Number.isFinite(gainPct)
+      ? (gainPct > 0 ? 'positive' : gainPct < 0 ? 'negative' : 'neutral')
+      : '';
+
+    const datasetCurrentValue = hasValue && Number.isFinite(currentValue) ? currentValue : '';
+    const datasetGainAbs = hasValue && Number.isFinite(gainAbs) ? gainAbs : '';
+    const datasetGainPct = hasValue && Number.isFinite(gainPct) ? gainPct : '';
+
+    let gainAbsAttributes = '';
+    if (gainPctLabel) {
+      gainAbsAttributes = ` data-gain-pct="${escapeAttribute(gainPctLabel)}" data-gain-sign="${escapeAttribute(gainPctSign)}"`;
+    }
+
+    html += `<tr class="portfolio-row"
+                data-portfolio="${d.uuid}"
+                data-position-count="${positionCount}"
+                data-current-value="${escapeAttribute(datasetCurrentValue)}"
+                data-purchase-sum="${escapeAttribute(purchaseSum)}"
+                data-gain-abs="${escapeAttribute(datasetGainAbs)}"
+                data-gain-pct="${escapeAttribute(datasetGainPct)}"
+                data-has-value="${hasValue ? 'true' : 'false'}">`;
+    html += `<td>
+        <button type="button"
+                class="${toggleClass}"
+                data-portfolio="${d.uuid}"
+                aria-expanded="${expanded ? 'true' : 'false'}"
+                aria-controls="${detailId}">
+          <span class="caret">${expanded ? '▼' : '▶'}</span>
+          <span class="portfolio-name">${d.name}</span>
+        </button>
+      </td>`;
+    html += `<td class="align-right">${positionCount}</td>`;
+    html += `<td class="align-right">${currentValueCell}</td>`;
+    html += `<td class="align-right"${gainAbsAttributes}>${gainAbsCell}</td>`;
+    html += `<td class="align-right gain-pct-cell">${gainPctCell}</td>`;
+    html += '</tr>';
+
+    html += `<tr class="portfolio-details${expanded ? '' : ' hidden'}"
+                data-portfolio="${d.uuid}"
+                id="${detailId}"
+                role="region"
+                aria-label="Positionen für ${d.name}">
+      <td colspan="5">
+        <div class="positions-container">${expanded
+        ? (portfolioPositionsCache.has(d.uuid)
+          ? renderPositionsTable(portfolioPositionsCache.get(d.uuid))
+          : '<div class=\"loading\">Lade Positionen...</div>')
+        : ''
+      }</div>
+      </td>
+    </tr>`;
+  });
+
+  const availableDepots = depots.filter(d => d && d.hasValue !== false);
+  const sumPositions = depots.reduce((a, d) => a + (Number.isFinite(d?.position_count) ? d.position_count : 0), 0);
+  const sumCurrent = availableDepots.reduce((a, d) => a + (Number.isFinite(d.current_value) ? d.current_value : 0), 0);
+  const sumPurchase = availableDepots.reduce((a, d) => a + (Number.isFinite(d.purchase_sum) ? d.purchase_sum : 0), 0);
+  const sumGainAbs = availableDepots.reduce((a, d) => {
+    const current = Number.isFinite(d.current_value) ? d.current_value : 0;
+    const purchase = Number.isFinite(d.purchase_sum) ? d.purchase_sum : 0;
+    return a + (current - purchase);
+  }, 0);
+  const sumHasValue = availableDepots.length === depots.length;
+  const sumGainPct = sumHasValue && sumPurchase > 0 ? (sumGainAbs / sumPurchase) * 100 : null;
+
+  const sumRowData = {
+    fx_unavailable: !sumHasValue,
+    current_value: sumHasValue ? sumCurrent : null,
+    gain_abs: sumHasValue ? sumGainAbs : null,
+    gain_pct: sumHasValue ? sumGainPct : null
+  };
+  const sumContext = { hasValue: sumHasValue };
+  const sumCurrentCell = formatValue('current_value', sumRowData.current_value, sumRowData, sumContext);
+  const sumGainAbsCell = formatValue('gain_abs', sumRowData.gain_abs, sumRowData, sumContext);
+  const sumGainPctCell = formatValue('gain_pct', sumRowData.gain_pct, sumRowData, sumContext);
+
+  let sumGainAbsAttributes = '';
+  if (sumHasValue && Number.isFinite(sumGainPct)) {
+    const sumGainPctLabel = `${formatNumber(sumGainPct)} %`;
+    const sumGainPctSign = sumGainPct > 0 ? 'positive' : sumGainPct < 0 ? 'negative' : 'neutral';
+    sumGainAbsAttributes = ` data-gain-pct="${escapeAttribute(sumGainPctLabel)}" data-gain-sign="${escapeAttribute(sumGainPctSign)}"`;
+  }
+
+  html += `<tr class="footer-row"
+    data-position-count="${sumPositions}"
+    data-current-value="${escapeAttribute(sumHasValue ? sumCurrent : '')}"
+    data-purchase-sum="${escapeAttribute(sumHasValue ? sumPurchase : '')}"
+    data-gain-abs="${escapeAttribute(sumHasValue ? sumGainAbs : '')}"
+    data-gain-pct="${escapeAttribute(sumHasValue && Number.isFinite(sumGainPct) ? sumGainPct : '')}"
+    data-has-value="${sumHasValue ? 'true' : 'false'}">
+    <td>Summe</td>
+    <td class="align-right">${Math.round(sumPositions).toLocaleString('de-DE')}</td>
+    <td class="align-right">${sumCurrentCell}</td>
+    <td class="align-right"${sumGainAbsAttributes}>${sumGainAbsCell}</td>
+    <td class="align-right gain-pct-cell">${sumGainPctCell}</td>
+  </tr>`;
+
+  html += '</tbody></table>';
+  return html;
+}
+
+function resolvePortfolioTable(target) {
+  if (target instanceof HTMLTableElement) {
+    return target;
+  }
+  if (target && typeof target.querySelector === 'function') {
+    return target.querySelector('table.expandable-portfolio-table') ||
+      target.querySelector('.portfolio-table table') ||
+      target.querySelector('table');
+  }
+  return document.querySelector('.portfolio-table table.expandable-portfolio-table') ||
+    document.querySelector('.portfolio-table table');
+}
+
+function readDatasetNumber(value) {
+  if (value === undefined) {
+    return null;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function extractNumericFromCell(cell) {
+  if (!cell) {
+    return 0;
+  }
+  const raw = cell.textContent || '';
+  if (!raw) {
+    return 0;
+  }
+  const cleaned = raw
+    .replace(/[^0-9,.-]/g, '')
+    .replace(/\./g, '')
+    .replace(',', '.');
+  const parsed = Number.parseFloat(cleaned);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function updatePortfolioFooterFromDom(target) {
+  const table = resolvePortfolioTable(target);
+  if (!table) {
+    return;
+  }
+  const tbody = table.tBodies?.[0];
+  if (!tbody) {
+    return;
+  }
+  const rows = Array.from(tbody.querySelectorAll('tr.portfolio-row'));
+  if (!rows.length) {
+    return;
+  }
+
+  let sumPositions = 0;
+  let sumCurrent = 0;
+  let sumPurchase = 0;
+  let sumGainAbs = 0;
+  let missingRows = 0;
+
+  for (const row of rows) {
+    const hasValueAttr = row.dataset.hasValue;
+    const hasValue = !(hasValueAttr === 'false' || hasValueAttr === '0' || hasValueAttr === '' || hasValueAttr == null);
+    const posCount = readDatasetNumber(row.dataset.positionCount) ?? extractNumericFromCell(row.cells[1]);
+    sumPositions += posCount;
+
+    if (!hasValue) {
+      missingRows += 1;
+      continue;
+    }
+
+    const currentValue = readDatasetNumber(row.dataset.currentValue) ?? extractNumericFromCell(row.cells[2]);
+    const gainAbs = readDatasetNumber(row.dataset.gainAbs) ?? extractNumericFromCell(row.cells[3]);
+    const purchaseSumDataset = readDatasetNumber(row.dataset.purchaseSum);
+    const purchaseSum = purchaseSumDataset != null ? purchaseSumDataset : (currentValue - gainAbs);
+
+    sumCurrent += currentValue;
+    sumGainAbs += gainAbs;
+    sumPurchase += purchaseSum;
+  }
+
+  const sumHasValue = missingRows === 0;
+  if (!sumHasValue && sumPurchase > 0) {
+    sumPurchase = sumCurrent - sumGainAbs;
+  }
+  if (sumHasValue && sumPurchase <= 0) {
+    sumPurchase = sumCurrent - sumGainAbs;
+  }
+
+  const sumGainPct = sumHasValue && sumPurchase > 0 ? (sumGainAbs / sumPurchase) * 100 : null;
+
+  let footer = Array.from(tbody.children).find((child) =>
+    child instanceof HTMLTableRowElement && child.classList.contains('footer-row')
+  );
+  if (!footer) {
+    footer = document.createElement('tr');
+    footer.classList.add('footer-row');
+    tbody.appendChild(footer);
+  }
+
+  const sumPositionsDisplay = Math.round(sumPositions).toLocaleString('de-DE');
+
+  const renderMissingValue = (reason = 'Wert nicht verfügbar') =>
+    `<span class="missing-value" role="note" aria-label="${reason}" title="${reason}">—</span>`;
+  const missingReason = 'Teilweise fehlende Wechselkurse – Wert unbekannt';
+
+  const currentValueHtml = sumHasValue
+    ? `${formatNumber(sumCurrent)}&nbsp;€`
+    : renderMissingValue(missingReason);
+  const gainAbsHtml = sumHasValue
+    ? formatGain(sumGainAbs)
+    : renderMissingValue(missingReason);
+  const gainPctHtml = sumHasValue && sumGainPct != null
+    ? formatGainPct(sumGainPct)
+    : renderMissingValue(missingReason);
+
+  footer.innerHTML = `
+    <td>Summe</td>
+    <td class="align-right">${sumPositionsDisplay}</td>
+    <td class="align-right">${currentValueHtml}</td>
+    <td class="align-right">${gainAbsHtml}</td>
+    <td class="align-right">${gainPctHtml}</td>
+  `;
+  footer.dataset.positionCount = String(Math.round(sumPositions));
+  footer.dataset.currentValue = sumHasValue ? String(sumCurrent) : '';
+  footer.dataset.purchaseSum = sumHasValue ? String(sumPurchase) : '';
+  footer.dataset.gainAbs = sumHasValue ? String(sumGainAbs) : '';
+  footer.dataset.gainPct = sumHasValue && sumGainPct != null ? String(sumGainPct) : '';
+  footer.dataset.hasValue = sumHasValue ? 'true' : 'false';
+}
+window.__ppReaderUpdatePortfolioFooter = updatePortfolioFooterFromDom;
+
+/**
+ * Utility-Funktionen zum Auslesen und Wiederherstellen des Expand-States.
+ * Perspektivisch nutzbar, falls ein vollständiger Neu-Render (Hard Refresh) der
+ * Depot-Tabelle nötig wird (z.B. beim späteren Hinzufügen von Filter-/Sortierlogik).
+ */
+export function getExpandedPortfolios() {
+  // Primär DOM lesen (falls Tabelle gerendert), Fallback: interner Set
+  const domRows = Array.from(document.querySelectorAll('.portfolio-details:not(.hidden)[data-portfolio]'));
+  if (domRows.length) {
+    return domRows.map(r => r.getAttribute('data-portfolio')).filter(Boolean);
+  }
+  return Array.from(expandedPortfolios.values());
+}
+
+export function setExpandedPortfolios(portfolioIds) {
+  expandedPortfolios.clear();
+  if (Array.isArray(portfolioIds)) {
+    portfolioIds.forEach(id => {
+      if (id) expandedPortfolios.add(id);
+    });
+  }
+}
+
+// NEU: Helper zum Anhängen der Sortier-Logik an eine Positions-Tabelle eines bestimmten Portfolios
+export function attachPortfolioPositionsSorting(root, portfolioUuid) {
+  if (!root || !portfolioUuid) return;
+  const detailsRow = root.querySelector(`.portfolio-details[data-portfolio="${portfolioUuid}"]`);
+  if (!detailsRow) return;
+  const container = detailsRow.querySelector('.positions-container');
+  if (!container) return;
+  const table = container.querySelector('table.sortable-positions');
+  if (!table || table.__ppReaderSortingBound) return;
+
+  table.__ppReaderSortingBound = true;
+
+  const applySort = (key, dir) => {
+    const tbody = table.querySelector('tbody');
+    if (!tbody) return;
+    const rows = Array.from(tbody.querySelectorAll('tr'))
+      .filter(r => !r.classList.contains('footer-row'));
+    const footer = tbody.querySelector('tr.footer-row');
+
+    const parseNum = (txt) => {
+      if (txt == null) return 0;
+      // Entferne Währungs-/Prozent-Symbole, geschützte Leerzeichen
+      return parseFloat(
+        txt.replace(/\u00A0/g, ' ')
+          .replace(/[%€]/g, '')
+          .replace(/\./g, '')
+          .replace(',', '.')
+          .replace(/[^\d.-]/g, '')
+      ) || 0;
+    };
+
+    rows.sort((a, b) => {
+      const idxMap = {
+        name: 0,
+        current_holdings: 1,
+        purchase_value: 2,
+        current_value: 3,
+        gain_abs: 4,
+        gain_pct: 5
+      };
+      const colIdx = idxMap[key];
+      if (colIdx == null) return 0;
+      const aCell = a.cells[colIdx]?.textContent.trim() || '';
+      const bCell = b.cells[colIdx]?.textContent.trim() || '';
+
+      let comp;
+      if (key === 'name') {
+        comp = aCell.localeCompare(bCell, 'de', { sensitivity: 'base' });
+      } else if (key === 'gain_pct') {
+        comp = parseNum(aCell) - parseNum(bCell);
+      } else {
+        comp = parseNum(aCell) - parseNum(bCell);
+      }
+      return dir === 'asc' ? comp : -comp;
+    });
+
+    // Visuelle Indikatoren zurücksetzen
+    table.querySelectorAll('thead th.sort-active').forEach(th => {
+      th.classList.remove('sort-active', 'dir-asc', 'dir-desc');
+    });
+
+    // Aktives TH markieren
+    const th = table.querySelector(`thead th[data-sort-key="${key}"]`);
+    if (th) {
+      th.classList.add('sort-active', dir === 'asc' ? 'dir-asc' : 'dir-desc');
+    }
+
+    // Neu einfügen
+    rows.forEach(r => tbody.appendChild(r));
+    if (footer) tbody.appendChild(footer);
+  };
+
+  // Initial ggf. gespeicherten Zustand anwenden
+  const currentKey = container.dataset.sortKey || table.dataset.defaultSort || 'name';
+  const currentDir = container.dataset.sortDir || table.dataset.defaultDir || 'asc';
+  applySort(currentKey, currentDir);
+
+  table.addEventListener('click', (e) => {
+    const th = e.target.closest('th[data-sort-key]');
+    if (!th || !table.contains(th)) return;
+    const key = th.getAttribute('data-sort-key');
+    if (!key) return;
+
+    let dir = 'asc';
+    if (container.dataset.sortKey === key) {
+      dir = container.dataset.sortDir === 'asc' ? 'desc' : 'asc';
+    }
+    container.dataset.sortKey = key;
+    container.dataset.sortDir = dir;
+    applySort(key, dir);
+  });
+}
+
+// Exponiere zentrale Sortier-Funktion global für Push-Handler (Race-frei wiederverwendbar)
+if (!window.__ppReaderAttachPortfolioPositionsSorting) {
+  window.__ppReaderAttachPortfolioPositionsSorting = attachPortfolioPositionsSorting;
+}
+
+// NEU: Funktion zum erneuten Laden der Positionsdaten
+async function reloadPortfolioPositions(portfolioUuid, containerEl, root) {
+  if (!portfolioUuid || !_hassRef || !_panelConfigRef) return;
+
+  const targetContainer = containerEl || root?.querySelector(
+    `.portfolio-details[data-portfolio="${portfolioUuid}"] .positions-container`
+  );
+  if (!targetContainer) {
+    return;
+  }
+
+  const detailsRow = targetContainer.closest('.portfolio-details');
+  if (detailsRow && detailsRow.classList.contains('hidden')) {
+    return; // Hidden Rows sollen keinen Silent-Preload anstoßen
+  }
+
+  targetContainer.innerHTML = '<div class="loading">Neu laden...</div>';
+  try {
+    const resp = await fetchPortfolioPositionsWS(_hassRef, _panelConfigRef, portfolioUuid);
+    if (resp.error) {
+      targetContainer.innerHTML = `<div class="error">${resp.error} <button class="retry-pos" data-portfolio="${portfolioUuid}">Erneut laden</button></div>`;
+      return;
+    }
+    const positions = resp.positions || [];
+    portfolioPositionsCache.set(portfolioUuid, positions);
+    targetContainer.innerHTML = renderPositionsTable(positions);
+    // Änderung 11: Nach erstmaligem Lazy-Load Sortierung initialisieren
+    try {
+      attachPortfolioPositionsSorting(root, portfolioUuid);
+    } catch (e) {
+      console.warn("attachPortfolioToggleHandler: Sort-Init (Lazy) fehlgeschlagen:", e);
+    }
+    try {
+      attachSecurityDetailListener(root, portfolioUuid);
+    } catch (e) {
+      console.warn('reloadPortfolioPositions: Security-Listener konnte nicht gebunden werden:', e);
+    }
+  } catch (e) {
+    targetContainer.innerHTML = `<div class="error">Fehler: ${e.message} <button class="retry-pos" data-portfolio="${portfolioUuid}">Retry</button></div>`;
+  }
+}
+
+// Hilfsfunktion: wartet bis ein Selektor im root existiert
+async function waitForElement(root, selector, timeoutMs = 3000, intervalMs = 50) {
+  const start = performance.now();
+  return new Promise((resolve) => {
+    const tick = () => {
+      const el = root.querySelector(selector);
+      if (el) return resolve(el);
+      if (performance.now() - start > timeoutMs) return resolve(null);
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+export function attachPortfolioToggleHandler(root) {
+  if (!root) return;
+
+  const token = (root.__ppReaderAttachToken ?? 0) + 1;
+  root.__ppReaderAttachToken = token;
+  root.__ppReaderAttachInProgress = true;
+
+  (async () => {
+    try {
+      const container = await waitForElement(root, '.portfolio-table');
+      if (token !== root.__ppReaderAttachToken) {
+        return; // Ein neuer Versuch läuft bereits – diesen abbrechen
+      }
+      if (!container) {
+        console.warn("attachPortfolioToggleHandler: .portfolio-table nicht gefunden (Timeout)");
+        return;
+      }
+
+      // Buttons generiert?
+      const btnCount = container.querySelectorAll('.portfolio-toggle').length;
+      if (btnCount === 0) {
+        console.debug("attachPortfolioToggleHandler: Noch keine Buttons – evtl. Recovery später");
+      }
+
+      if (container.__ppReaderPortfolioToggleBound) {
+        return;
+      }
+      container.__ppReaderPortfolioToggleBound = true;
+      console.debug("attachPortfolioToggleHandler: Listener registriert");
+
+      container.addEventListener('click', async (e) => {
+      try {
+        const retryBtn = e.target.closest('.retry-pos');
+        if (retryBtn && container.contains(retryBtn)) {
+          const pid = retryBtn.getAttribute('data-portfolio');
+          const detailsRow = root.querySelector(`.portfolio-details[data-portfolio="${pid}"]`);
+          const cont = detailsRow?.querySelector('.positions-container');
+          await reloadPortfolioPositions(pid, cont, root);
+          return;
+        }
+
+        const btn = e.target.closest('.portfolio-toggle');
+        if (!btn || !container.contains(btn)) return;
+
+        const portfolioUuid = btn.getAttribute('data-portfolio');
+        if (!portfolioUuid) return;
+
+        const detailsRow = root.querySelector(`.portfolio-details[data-portfolio="${portfolioUuid}"]`);
+        if (!detailsRow) return;
+
+        const caretEl = btn.querySelector('.caret');
+        const isHidden = detailsRow.classList.contains('hidden');
+
+        if (isHidden) {
+          detailsRow.classList.remove('hidden');
+          btn.classList.add('expanded');
+          btn.setAttribute('aria-expanded', 'true');
+          if (caretEl) caretEl.textContent = '▼';
+          expandedPortfolios.add(portfolioUuid);
+
+          let pendingApplied = false;
+          try {
+            pendingApplied = flushPendingPositions(root, portfolioUuid);
+          } catch (e) {
+            console.warn('attachPortfolioToggleHandler: Pending-Flush fehlgeschlagen:', e);
+          }
+          if (!pendingApplied && window.__ppReaderFlushPendingPositions) {
+            try {
+              pendingApplied = window.__ppReaderFlushPendingPositions(root, portfolioUuid);
+            } catch (e) {
+              console.warn('attachPortfolioToggleHandler: Global Pending-Flush fehlgeschlagen:', e);
+            }
+          }
+
+          if (!portfolioPositionsCache.has(portfolioUuid)) {
+            const containerEl = detailsRow.querySelector('.positions-container');
+            if (containerEl) containerEl.innerHTML = '<div class="loading">Lade Positionen...</div>';
+            try {
+              const resp = await fetchPortfolioPositionsWS(_hassRef, _panelConfigRef, portfolioUuid);
+              if (resp.error) {
+                if (containerEl) {
+                  containerEl.innerHTML = `<div class="error">${resp.error} <button class="retry-pos" data-portfolio="${portfolioUuid}">Erneut laden</button></div>`;
+                }
+                return;
+              }
+              const positions = (resp && resp.positions) || [];
+              portfolioPositionsCache.set(portfolioUuid, positions);
+              if (containerEl) {
+                containerEl.innerHTML = renderPositionsTable(positions);
+                // Änderung 11: Nach erstmaligem Lazy-Load Sortierung initialisieren
+                try {
+                  attachPortfolioPositionsSorting(root, portfolioUuid);
+                } catch (e) {
+                  console.warn("attachPortfolioToggleHandler: Sort-Init (Lazy) fehlgeschlagen:", e);
+                }
+                try {
+                  attachSecurityDetailListener(root, portfolioUuid);
+                } catch (e) {
+                  console.warn('attachPortfolioToggleHandler: Security-Listener konnte nicht gebunden werden:', e);
+                }
+              }
+            } catch (err) {
+              const containerEl = detailsRow.querySelector('.positions-container');
+              if (containerEl) {
+                containerEl.innerHTML = `<div class="error">Fehler beim Laden: ${err.message} <button class="retry-pos" data-portfolio="${portfolioUuid}">Retry</button></div>`;
+              }
+              console.error('Fehler beim Lazy Load für', portfolioUuid, err);
+            }
+          } else {
+            const containerEl = detailsRow.querySelector('.positions-container');
+            if (containerEl) {
+              containerEl.innerHTML = renderPositionsTable(portfolioPositionsCache.get(portfolioUuid));
+              attachPortfolioPositionsSorting(root, portfolioUuid);
+              try {
+                attachSecurityDetailListener(root, portfolioUuid);
+              } catch (e) {
+                console.warn('attachPortfolioToggleHandler: Security-Listener (Cache) Fehler:', e);
+              }
+            }
+          }
+        } else {
+          detailsRow.classList.add('hidden');
+          btn.classList.remove('expanded');
+          btn.setAttribute('aria-expanded', 'false');
+          if (caretEl) caretEl.textContent = '▶';
+          expandedPortfolios.delete(portfolioUuid);
+        }
+      } catch (err) {
+        console.error("attachPortfolioToggleHandler: Ungefangener Fehler im Click-Handler", err);
+      }
+      });
+    } finally {
+      if (token === root.__ppReaderAttachToken) {
+        root.__ppReaderAttachInProgress = false;
+      }
+    }
+  })();
+}
+
+// Fallback: direkter Listener auf die Tabelle selbst (falls outer container nicht klickt)
+export function ensurePortfolioRowFallbackListener(root) {
+  const table = root.querySelector('.expandable-portfolio-table');
+  if (!table) return;
+  if (table.__ppReaderPortfolioFallbackBound) return;
+  table.__ppReaderPortfolioFallbackBound = true;
+  table.addEventListener('click', (e) => {
+    const btn = e.target.closest('.portfolio-toggle');
+    if (!btn) return;
+    // Falls der Haupt-Listener schon aktiv war, nichts doppelt machen
+    if (root.querySelector('.portfolio-table').__ppReaderPortfolioToggleBound) return;
+    console.debug("Fallback-Listener aktiv – re-attach Hauptlistener");
+    attachPortfolioToggleHandler(root);
+  });
+}
+
+export async function renderDashboard(root, hass, panelConfig) {
+  _hassRef = hass;
+  _panelConfigRef = panelConfig;
+  console.debug("renderDashboard: start – panelConfig:", panelConfig?.config, "derived entry_id?", panelConfig?.config?._panel_custom?.config?.entry_id);
+
+  const accountsResp = await fetchAccountsWS(hass, panelConfig);
+  const accounts = (accountsResp && accountsResp.accounts) || [];
+
+  const portfoliosResp = await fetchPortfoliosWS(hass, panelConfig);
+  let depots = (portfoliosResp.portfolios || []).map(p => {
+    const missingPositions = typeof p.missing_value_positions === 'number'
+      ? p.missing_value_positions
+      : 0;
+    const hasCurrentValue = p.has_current_value != null
+      ? Boolean(p.has_current_value)
+      : missingPositions === 0;
+    const baseCurrentValue = typeof p.current_value === 'number' ? p.current_value : 0;
+    const purchase_sum = typeof p.purchase_sum === 'number' ? p.purchase_sum : 0;
+    const current_value = hasCurrentValue ? baseCurrentValue : null;
+    const gain_abs = hasCurrentValue ? baseCurrentValue - purchase_sum : null;
+    const gain_pct = hasCurrentValue && purchase_sum > 0 ? (gain_abs / purchase_sum) * 100 : null;
+    return {
+      uuid: p.uuid,
+      name: p.name,
+      position_count: typeof p.position_count === 'number' ? p.position_count : 0,
+      current_value,
+      purchase_sum,
+      gain_abs,
+      gain_pct,
+      hasValue: hasCurrentValue,
+      missing_value_positions: missingPositions,
+      fx_unavailable: !hasCurrentValue
+    };
+  });
+
+  // 3. Last file update (optional – falls bereits WS-Command vorhanden)
+  let lastFileUpdate = '';
+  try {
+    lastFileUpdate = await fetchLastFileUpdateWS(hass, panelConfig);
+  } catch {
+    lastFileUpdate = '';
+  }
+
+  // 4. Gesamtvermögen berechnen (nur Anzeige)
+  const totalAccounts = accounts.reduce(
+    (sum, account) => sum + (Number.isFinite(account.balance) ? account.balance : 0),
+    0,
+  );
+  const anyPortfolioMissing = depots.some(depot => depot.hasValue === false);
+  const totalDepots = depots.reduce(
+    (sum, depot) => sum + ((depot.hasValue && Number.isFinite(depot.current_value)) ? depot.current_value : 0),
+    0,
+  );
+  const totalWealth = totalAccounts + totalDepots;
+  const missingWealthReason = 'Teilweise fehlende Wechselkurse – Gesamtvermögen unbekannt';
+  const wealthValueMarkup = anyPortfolioMissing
+    ? `<span class="missing-value" role="note" aria-label="${missingWealthReason}" title="${missingWealthReason}">—</span>`
+    : `${formatNumber(totalWealth)}&nbsp;€`;
+  const wealthNote = anyPortfolioMissing
+    ? `<span class="total-wealth-note">${missingWealthReason}</span>`
+    : '';
+
+  // 5. Header (ohne Last-File-Update – kommt jetzt wieder in Footer-Karte)
+  const headerMeta = `
+    <div class="header-meta-row">
+      💰 Gesamtvermögen: <strong class="total-wealth-value">${wealthValueMarkup}</strong>${wealthNote}
+    </div>
+  `;
+  const headerCard = createHeaderCard('Übersicht', headerMeta);
+
+  // 6. Sicherstellen, dass die Struktur exakt der erwartet wird:
+  //    - .portfolio-table (Wrapper)
+  //    - darin eine <table class="expandable-portfolio-table"> mit <tr class="portfolio-row" data-portfolio="UUID">
+  const portfolioTableHtml = buildExpandablePortfolioTable(depots);
+
+  // 7. Konten-Tabellen
+  const eurAccounts = accounts.filter(a => (a.currency_code || 'EUR') === 'EUR');
+  const fxAccounts = accounts.filter(a => (a.currency_code || 'EUR') !== 'EUR');
+
+  const fxWarningNeeded = fxAccounts.some(a => a.fx_unavailable);
+  const fxWarning = fxWarningNeeded
+    ? `
+        <p class="table-note" role="note">
+          <span class="table-note__icon" aria-hidden="true">⚠️</span>
+          <span>Wechselkurse konnten nicht geladen werden. EUR-Werte werden derzeit nicht angezeigt.</span>
+        </p>
+      `
+    : '';
+
+  const accountsHtml = `
+    <div class="card">
+      <h2>Liquidität</h2>
+      <div class="scroll-container account-table">
+        ${makeTable(eurAccounts, [
+    { key: 'name', label: 'Name' },
+    { key: 'balance', label: 'Kontostand (EUR)', align: 'right' }
+  ], ['balance'])}
+      </div>
+    </div>
+    ${fxAccounts.length ? `
+      <div class="card">
+        <h2>Fremdwährungen</h2>
+        <div class="scroll-container fx-account-table">
+          ${makeTable(
+    fxAccounts.map(a => ({
+      ...a,
+      fx_display: `${(a.orig_balance ?? 0).toLocaleString('de-DE', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      })}&nbsp;${a.currency_code}`
+    })),
+    [
+      { key: 'name', label: 'Name' },
+      { key: 'fx_display', label: 'Betrag (FX)' },
+      { key: 'balance', label: 'EUR', align: 'right' }
+    ],
+    ['balance']
+  )}
+        </div>
+        ${fxWarning}
+      </div>` : ''}
+  `;
+
+  // 8. Footer-Karte mit letztem Datei-Änderungszeitpunkt (reintroduziert)
+  const footerCard = `
+    <div class="card footer-card">
+      <div class="meta">
+        <div class="last-file-update">
+          📂 Letzte Aktualisierung der Datei: <strong>${lastFileUpdate || 'Unbekannt'}</strong>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const markup = `
+    ${headerCard.outerHTML}
+    <div class="card">
+      <h2>Investment</h2>
+      <div class="scroll-container portfolio-table">
+        ${portfolioTableHtml}
+      </div>
+    </div>
+    ${accountsHtml}
+    ${footerCard}
+  `;
+
+  schedulePostRenderSetup(root, depots);
+
+  return markup;
+}
+
+function schedulePostRenderSetup(root, depots) {
+  if (!root) {
+    return;
+  }
+
+  const run = () => {
+    try {
+      const wrapper = root;
+      const tableHost = wrapper.querySelector('.portfolio-table');
+      if (tableHost && tableHost.querySelectorAll('.portfolio-toggle').length === 0) {
+        console.debug('Recovery: Tabelle ohne Buttons – erneuter Aufbau');
+        tableHost.innerHTML = buildExpandablePortfolioTable(depots);
+      }
+
+      attachPortfolioToggleHandler(root);
+      ensurePortfolioRowFallbackListener(root);
+
+      expandedPortfolios.forEach((pid) => {
+        try {
+          if (portfolioPositionsCache.has(pid)) {
+            attachPortfolioPositionsSorting(root, pid);
+            attachSecurityDetailListener(root, pid);
+          }
+        } catch (e) {
+          console.warn('Init-Sortierung für expandiertes Depot fehlgeschlagen:', pid, e);
+        }
+      });
+
+      try {
+        updatePortfolioFooterFromDom(wrapper);
+      } catch (footerErr) {
+        console.warn('renderDashboard: Footer-Summe konnte nicht aktualisiert werden:', footerErr);
+      }
+
+      try {
+        flushAllPendingPositions(root);
+      } catch (pendingErr) {
+        console.warn('renderDashboard: Pending-Positions konnten nicht angewendet werden:', pendingErr);
+      }
+
+      console.debug('renderDashboard: portfolio-toggle Buttons:', wrapper.querySelectorAll('.portfolio-toggle').length);
+    } catch (e) {
+      console.error('renderDashboard: Fehler bei Recovery/Listener', e);
+    }
+  };
+
+  const schedule = typeof requestAnimationFrame === 'function'
+    ? (cb) => requestAnimationFrame(cb)
+    : (cb) => setTimeout(cb, 0);
+
+  schedule(() => schedule(run));
+}

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -1,0 +1,870 @@
+// @ts-nocheck
+
+/**
+ * Security detail tab renderer migrated verbatim for TypeScript.
+ */
+
+/**
+ * Security detail tab renderer and registration.
+ *
+ * Provides the render function used by dynamic security tabs and
+ * exposes a helper to register the descriptor factory with the
+ * dashboard controller.
+ */
+import { createHeaderCard, formatNumber, formatGain } from '../content/elements.js';
+import { renderLineChart, updateLineChart } from '../content/charting.js';
+import { fetchSecuritySnapshotWS, fetchSecurityHistoryWS } from '../data/api.js';
+
+const HOLDINGS_FRACTION_DIGITS = { min: 0, max: 6 };
+const PRICE_FRACTION_DIGITS = { min: 2, max: 4 };
+const PRICE_SCALE = 1e8;
+const DEFAULT_HISTORY_RANGE = '1Y';
+const AVAILABLE_HISTORY_RANGES = ['1M', '6M', '1Y', '5Y'];
+const RANGE_DAY_COUNTS = {
+  '1M': 30,
+  '6M': 182,
+  '1Y': 365,
+  '5Y': 1826,
+};
+
+const SECURITY_HISTORY_CACHE = new Map(); // securityUuid -> Map(rangeKey -> series[])
+const RANGE_STATE_REGISTRY = new Map(); // securityUuid -> { activeRange }
+const LIVE_UPDATE_EVENT = 'pp-reader:portfolio-positions-updated';
+const LIVE_UPDATE_HANDLERS = new Map(); // securityUuid -> handler
+
+function buildCachedSnapshotNotice({ fallbackUsed, flaggedAsCache }) {
+  const reasons = [];
+  if (fallbackUsed) {
+    reasons.push(
+      'Der aktuelle Snapshot konnte nicht geladen werden. Es werden die zuletzt gespeicherten Werte angezeigt.',
+    );
+  }
+  if (flaggedAsCache && !fallbackUsed) {
+    reasons.push(
+      'Der Snapshot ist vom Datenanbieter als Zwischenspeicherstand markiert.',
+    );
+  }
+
+  const reasonText = reasons.length
+    ? reasons.join(' ')
+    : 'Die Daten stammen aus dem Zwischenspeicher.';
+
+  return `
+    <div class="card warning-card stale-notice" role="status" aria-live="polite">
+      <h2>Zwischengespeicherte Werte</h2>
+      <p>${reasonText}</p>
+      <p class="stale-notice__hint">Die angezeigten Beträge können von den aktuellen Marktwerten abweichen. Laden Sie die Ansicht erneut, sobald eine Verbindung verfügbar ist.</p>
+    </div>
+  `;
+}
+
+function getCachedSecuritySnapshot(securityUuid) {
+  if (!securityUuid || typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const getter = window.__ppReaderGetSecuritySnapshotFromCache;
+    if (typeof getter === 'function') {
+      const snapshot = getter(securityUuid);
+      return snapshot && typeof snapshot === 'object' ? snapshot : null;
+    }
+  } catch (error) {
+    console.warn('getCachedSecuritySnapshot: Zugriff auf Cache fehlgeschlagen', error);
+  }
+
+  return null;
+}
+
+function ensureHistoryCache(securityUuid) {
+  if (!SECURITY_HISTORY_CACHE.has(securityUuid)) {
+    SECURITY_HISTORY_CACHE.set(securityUuid, new Map());
+  }
+  return SECURITY_HISTORY_CACHE.get(securityUuid);
+}
+
+function invalidateHistoryCache(securityUuid) {
+  if (!securityUuid) {
+    return;
+  }
+
+  if (SECURITY_HISTORY_CACHE.has(securityUuid)) {
+    try {
+      const cache = SECURITY_HISTORY_CACHE.get(securityUuid);
+      if (cache && typeof cache.clear === 'function') {
+        cache.clear();
+      }
+    } catch (error) {
+      console.warn('invalidateHistoryCache: Konnte Cache nicht leeren', securityUuid, error);
+    }
+    SECURITY_HISTORY_CACHE.delete(securityUuid);
+  }
+}
+
+function handleLiveUpdateForSecurity(securityUuid, detail) {
+  if (!securityUuid || !detail) {
+    return;
+  }
+
+  const payload = detail.securityUuids;
+  const candidates = Array.isArray(payload) ? payload : [];
+
+  if (candidates.includes(securityUuid)) {
+    invalidateHistoryCache(securityUuid);
+  }
+}
+
+function ensureLiveUpdateSubscription(securityUuid) {
+  if (!securityUuid || LIVE_UPDATE_HANDLERS.has(securityUuid)) {
+    return;
+  }
+
+  const handler = (event) => {
+    if (!event || !event.detail) {
+      return;
+    }
+    handleLiveUpdateForSecurity(securityUuid, event.detail);
+  };
+
+  try {
+    window.addEventListener(LIVE_UPDATE_EVENT, handler);
+    LIVE_UPDATE_HANDLERS.set(securityUuid, handler);
+  } catch (error) {
+    console.error('ensureLiveUpdateSubscription: Registrierung fehlgeschlagen', error);
+  }
+}
+
+function removeLiveUpdateSubscription(securityUuid) {
+  if (!securityUuid || !LIVE_UPDATE_HANDLERS.has(securityUuid)) {
+    return;
+  }
+
+  const handler = LIVE_UPDATE_HANDLERS.get(securityUuid);
+  try {
+    window.removeEventListener(LIVE_UPDATE_EVENT, handler);
+  } catch (error) {
+    console.error('removeLiveUpdateSubscription: Entfernen des Listeners fehlgeschlagen', error);
+  }
+
+  LIVE_UPDATE_HANDLERS.delete(securityUuid);
+}
+
+function cleanupSecurityDetailState(securityUuid) {
+  if (!securityUuid) {
+    return;
+  }
+
+  removeLiveUpdateSubscription(securityUuid);
+  invalidateHistoryCache(securityUuid);
+  // RANGE_STATE_REGISTRY intentionally left intact so the last chosen
+  // range remains active when the user reopens the security detail.
+}
+
+function setActiveRange(securityUuid, rangeKey) {
+  if (!RANGE_STATE_REGISTRY.has(securityUuid)) {
+    RANGE_STATE_REGISTRY.set(securityUuid, { activeRange: rangeKey });
+    return;
+  }
+  const state = RANGE_STATE_REGISTRY.get(securityUuid);
+  state.activeRange = rangeKey;
+}
+
+function getActiveRange(securityUuid) {
+  return RANGE_STATE_REGISTRY.get(securityUuid)?.activeRange || DEFAULT_HISTORY_RANGE;
+}
+
+function toEpochDay(date) {
+  // Portfolio Performance liefert Datumswerte als epoch day (Tage seit 1970-01-01).
+  // Vorher wurde ein "YYYYMMDD" Format verwendet, wodurch alle Filter leer liefen
+  // und die Historie im Frontend dauerhaft als leer angezeigt wurde. Mit der
+  // Umstellung auf eine echte Epoch-Day-Berechnung sprechen Frontend und Backend
+  // wieder dieselbe Sprache und historische Kurse werden korrekt geladen.
+  const epochMs = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+  );
+  return Math.floor(epochMs / 86400000);
+}
+
+function normaliseDate(date) {
+  const clone = new Date(date.getTime());
+  clone.setUTCHours(0, 0, 0, 0);
+  return clone;
+}
+
+function resolveRangeOptions(rangeKey) {
+  const now = normaliseDate(new Date());
+  const rangeDays = RANGE_DAY_COUNTS[rangeKey];
+  const options = { end_date: toEpochDay(now) };
+
+  if (Number.isFinite(rangeDays) && rangeDays > 0) {
+    const start = new Date(now.getTime());
+    start.setUTCDate(start.getUTCDate() - (rangeDays - 1));
+    options.start_date = toEpochDay(start);
+  }
+
+  return options;
+}
+
+function parseHistoryDate(raw) {
+  if (!raw) {
+    return null;
+  }
+
+  if (raw instanceof Date && !Number.isNaN(raw.getTime())) {
+    return new Date(raw.getTime());
+  }
+
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    // Backend liefert Epoch Days (Tage seit 1970-01-01).
+    const timestamp = raw * 86400000;
+    if (Number.isFinite(timestamp)) {
+      return new Date(timestamp);
+    }
+  }
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (/^\d{8}$/.test(trimmed)) {
+      const year = Number.parseInt(trimmed.slice(0, 4), 10);
+      const month = Number.parseInt(trimmed.slice(4, 6), 10) - 1;
+      const day = Number.parseInt(trimmed.slice(6, 8), 10);
+      if (
+        Number.isFinite(year) &&
+        Number.isFinite(month) &&
+        Number.isFinite(day)
+      ) {
+        const date = new Date(Date.UTC(year, month, day));
+        if (!Number.isNaN(date.getTime())) {
+          return date;
+        }
+      }
+    }
+
+    const parsed = Date.parse(trimmed);
+    if (Number.isFinite(parsed)) {
+      return new Date(parsed);
+    }
+  }
+
+  return null;
+}
+
+function normaliseHistorySeries(prices) {
+  if (!Array.isArray(prices)) {
+    return [];
+  }
+
+  return prices
+    .map(entry => {
+      const rawClose = Number(entry?.close);
+      if (!Number.isFinite(rawClose)) {
+        return null;
+      }
+
+      const dateValue = parseHistoryDate(entry?.date);
+
+      return {
+        date: dateValue || entry?.date,
+        close: rawClose / PRICE_SCALE,
+      };
+    })
+    .filter(Boolean);
+}
+
+function deriveFxRate(snapshot, latestNativePrice) {
+  const currency = String(snapshot?.currency_code || '').toUpperCase();
+  if (!currency || currency === 'EUR') {
+    // Kein Fremdwährungsrisiko – Werte liegen bereits in EUR vor.
+    return 1;
+  }
+
+  const lastPriceEurRaw = snapshot?.last_price_eur;
+  const lastPriceEur = Number.isFinite(lastPriceEurRaw)
+    ? lastPriceEurRaw
+    : Number.parseFloat(lastPriceEurRaw);
+
+  if (!Number.isFinite(lastPriceEur) || lastPriceEur <= 0) {
+    // Ohne EUR-Referenzkurs können wir nicht in EUR umrechnen.
+    return null;
+  }
+
+  const snapshotNativeRaw = snapshot?.last_price_native;
+  const snapshotNative = Number.isFinite(snapshotNativeRaw)
+    ? snapshotNativeRaw
+    : Number.parseFloat(snapshotNativeRaw);
+
+  if (Number.isFinite(snapshotNative) && snapshotNative > 0) {
+    return lastPriceEur / snapshotNative;
+  }
+
+  const historyNative = Number.isFinite(latestNativePrice)
+    ? latestNativePrice
+    : Number.parseFloat(latestNativePrice);
+  if (Number.isFinite(historyNative) && historyNative > 0) {
+    return lastPriceEur / historyNative;
+  }
+
+  return null;
+}
+
+function roundCurrency(value) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  const rounded = Math.round(value * 100) / 100;
+  return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+function computeGainValues(historySeries, holdings, fxRate) {
+  if (!Array.isArray(historySeries) || historySeries.length === 0) {
+    return { periodGain: null, dailyGain: null };
+  }
+
+  const holdingsNumeric = Number.isFinite(holdings)
+    ? holdings
+    : Number.parseFloat(holdings);
+  const safeHoldings = Number.isFinite(holdingsNumeric) ? holdingsNumeric : 0;
+  const safeFx = Number.isFinite(fxRate) && fxRate > 0 ? fxRate : null;
+
+  if (safeFx == null) {
+    return { periodGain: null, dailyGain: null };
+  }
+
+  const lastEntry = historySeries[historySeries.length - 1];
+  const firstEntry = historySeries[0];
+  const previousEntry =
+    historySeries.length >= 2 ? historySeries[historySeries.length - 2] : null;
+
+  const periodDiff = (lastEntry.close - firstEntry.close) * safeHoldings * safeFx;
+  const dailyDiff = previousEntry
+    ? (lastEntry.close - previousEntry.close) * safeHoldings * safeFx
+    : null;
+
+  return {
+    periodGain: roundCurrency(periodDiff),
+    dailyGain: roundCurrency(dailyDiff),
+  };
+}
+
+function formatGainValue(value) {
+  if (value == null || Number.isNaN(value)) {
+    return '<span class="value neutral">—</span>';
+  }
+
+  return `<span class="value">${formatGain(value)}</span>`;
+}
+
+function buildInfoBar(rangeKey, periodGain, dailyGain) {
+  const rangeLabel = rangeKey ? rangeKey : '';
+  return `
+    <div class="security-info-bar" data-range="${rangeLabel}">
+      <div class="security-info-item">
+        <span class="label">Gesamt (${rangeLabel || 'Zeitraum'})</span>
+        ${formatGainValue(periodGain)}
+      </div>
+      <div class="security-info-item">
+        <span class="label">Letzter Tag</span>
+        ${formatGainValue(dailyGain)}
+      </div>
+    </div>
+  `;
+}
+
+function buildRangeSelector(activeRange) {
+  const buttons = AVAILABLE_HISTORY_RANGES.map((rangeKey) => {
+    const activeClass = rangeKey === activeRange ? ' active' : '';
+    return `
+      <button
+        type="button"
+        class="security-range-button${activeClass}"
+        data-range="${rangeKey}"
+        aria-pressed="${rangeKey === activeRange}"
+      >
+        ${rangeKey}
+      </button>
+    `;
+  });
+
+  return `
+    <div class="security-range-selector" role="group" aria-label="Zeitraum">
+      ${buttons.join('\n')}
+    </div>
+  `;
+}
+
+function buildHistoryPlaceholder(rangeKey, state = { status: 'empty' }) {
+  const safeRange = rangeKey || '';
+
+  switch (state.status) {
+    case 'loaded':
+      return `
+        <div
+          class="history-chart"
+          data-state="loaded"
+          data-range="${safeRange}"
+          role="img"
+          aria-label="Preisverlauf${safeRange ? ` für ${safeRange}` : ''}"
+        ></div>
+      `;
+    case 'error': {
+      const message = state?.message
+        ? String(state.message)
+        : 'Die historischen Daten konnten nicht geladen werden.';
+      return `
+        <div class="history-placeholder" data-state="error" data-range="${safeRange}">
+          <p>${message}</p>
+        </div>
+      `;
+    }
+    case 'empty':
+    default:
+      return `
+        <div class="history-placeholder" data-state="empty" data-range="${safeRange}">
+          <p>Für dieses Wertpapier liegen im Zeitraum ${safeRange || 'den gewählten Zeitraum'} keine historischen Daten vor.</p>
+        </div>
+      `;
+  }
+}
+
+function formatHoldings(value) {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+
+  const numeric = Number.isFinite(value) ? value : Number.parseFloat(value) || 0;
+  const hasFraction = Math.abs(numeric % 1) > 0;
+  const minFraction = hasFraction ? 2 : HOLDINGS_FRACTION_DIGITS.min;
+  const maxFraction = hasFraction ? HOLDINGS_FRACTION_DIGITS.max : HOLDINGS_FRACTION_DIGITS.min;
+  return numeric.toLocaleString('de-DE', {
+    minimumFractionDigits: minFraction,
+    maximumFractionDigits: maxFraction,
+  });
+}
+
+function formatPrice(value) {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+
+  const numeric = Number.isFinite(value) ? value : Number.parseFloat(value) || 0;
+  return numeric.toLocaleString('de-DE', {
+    minimumFractionDigits: PRICE_FRACTION_DIGITS.min,
+    maximumFractionDigits: PRICE_FRACTION_DIGITS.max,
+  });
+}
+
+function buildHeaderMeta(snapshot) {
+  if (!snapshot) {
+    return '<div class="meta-error">Keine Snapshot-Daten verfügbar.</div>';
+  }
+
+  const currency = snapshot.currency_code || 'EUR';
+  const holdings = formatHoldings(snapshot.total_holdings);
+  const lastPriceNative =
+    snapshot.last_price_native ?? snapshot.last_price?.native ?? snapshot.last_price_eur;
+  const formattedLastPrice = formatPrice(lastPriceNative);
+  const lastPriceDisplay =
+    formattedLastPrice === '—'
+      ? '—'
+      : `${formattedLastPrice}${currency ? `&nbsp;${currency}` : ''}`;
+  const marketValue = formatNumber(
+    snapshot.market_value_eur ?? snapshot.current_value_eur ?? 0,
+  );
+
+  return `
+    <div class="security-meta-grid">
+      <div class="security-meta-item">
+        <span class="label">Währung</span>
+        <span class="value">${currency}</span>
+      </div>
+      <div class="security-meta-item">
+        <span class="label">Bestand</span>
+        <span class="value">${holdings}</span>
+      </div>
+      <div class="security-meta-item">
+        <span class="label">Letzter Preis (${currency})</span>
+        <span class="value">${lastPriceDisplay}</span>
+      </div>
+      <div class="security-meta-item">
+        <span class="label">Marktwert (EUR)</span>
+        <span class="value">${marketValue}&nbsp;€</span>
+      </div>
+    </div>
+  `;
+}
+
+function normaliseHistoryError(error) {
+  if (!error) {
+    return null;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message || null;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch (_jsonError) {
+    return String(error);
+  }
+}
+
+export async function renderSecurityDetail(root, hass, panelConfig, securityUuid) {
+  if (!securityUuid) {
+    console.error('renderSecurityDetail: securityUuid fehlt');
+    return '<div class="card"><h2>Fehler</h2><p>Kein Wertpapier angegeben.</p></div>';
+  }
+
+  const cachedSnapshot = getCachedSecuritySnapshot(securityUuid);
+  let snapshot = null;
+  let error = null;
+
+  try {
+    const response = await fetchSecuritySnapshotWS(
+      hass,
+      panelConfig,
+      securityUuid,
+    );
+    if (response && typeof response === 'object') {
+      snapshot =
+        response.snapshot && typeof response.snapshot === 'object'
+          ? response.snapshot
+          : response;
+    } else {
+      snapshot = response;
+    }
+  } catch (err) {
+    console.error('renderSecurityDetail: Snapshot konnte nicht geladen werden', err);
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  const effectiveSnapshot = snapshot || cachedSnapshot;
+  const fallbackUsed = Boolean(cachedSnapshot && !snapshot);
+  const flaggedAsCache = effectiveSnapshot?.source === 'cache';
+  const staleNotice =
+    effectiveSnapshot && (fallbackUsed || flaggedAsCache)
+      ? buildCachedSnapshotNotice({ fallbackUsed, flaggedAsCache })
+      : '';
+  const headerTitle = effectiveSnapshot?.name || 'Wertpapierdetails';
+  const headerCard = createHeaderCard(headerTitle, buildHeaderMeta(effectiveSnapshot));
+
+  if (error) {
+    return `
+      ${headerCard.outerHTML}
+      ${staleNotice}
+      <div class="card error-card">
+        <h2>Fehler beim Laden</h2>
+        <p>${error}</p>
+      </div>
+    `;
+  }
+
+  const activeRange = getActiveRange(securityUuid);
+  const cache = ensureHistoryCache(securityUuid);
+  let historySeries = cache.has(activeRange) ? cache.get(activeRange) : null;
+  let historyState = { status: 'empty' };
+
+  if (Array.isArray(historySeries)) {
+    historyState = historySeries.length
+      ? { status: 'loaded' }
+      : { status: 'empty' };
+  } else {
+    historySeries = [];
+    try {
+      const rangeOptions = resolveRangeOptions(activeRange);
+      const historyResponse = await fetchSecurityHistoryWS(
+        hass,
+        panelConfig,
+        securityUuid,
+        rangeOptions,
+      );
+      historySeries = normaliseHistorySeries(historyResponse?.prices);
+      cache.set(activeRange, historySeries);
+      historyState = historySeries.length
+        ? { status: 'loaded' }
+        : { status: 'empty' };
+    } catch (historyError) {
+      console.error(
+        'renderSecurityDetail: Historie konnte nicht geladen werden',
+        historyError,
+      );
+      const message = normaliseHistoryError(historyError);
+      historyState = {
+        status: 'error',
+        message:
+          message ||
+          'Die historischen Daten konnten aufgrund eines Fehlers nicht geladen werden.',
+      };
+    }
+  }
+
+  const latestNativePrice =
+    historySeries.length > 0
+      ? historySeries[historySeries.length - 1].close
+      : effectiveSnapshot?.last_price_native;
+  const fxRate = deriveFxRate(effectiveSnapshot, latestNativePrice);
+  const holdings = effectiveSnapshot?.total_holdings ?? 0;
+  const { periodGain, dailyGain } = computeGainValues(
+    historySeries,
+    holdings,
+    fxRate,
+  );
+  const infoBar = buildInfoBar(activeRange, periodGain, dailyGain);
+
+  scheduleRangeSetup({
+    root,
+    hass,
+    panelConfig,
+    securityUuid,
+    snapshot: effectiveSnapshot,
+    holdings,
+    initialRange: activeRange,
+    initialHistory: historySeries,
+    initialHistoryState: historyState,
+  });
+
+  return `
+    ${headerCard.outerHTML}
+    ${staleNotice}
+    ${infoBar}
+    ${buildRangeSelector(activeRange)}
+    <div class="card security-detail-placeholder">
+      <h2>Historie</h2>
+      ${buildHistoryPlaceholder(activeRange, historyState)}
+    </div>
+  `;
+}
+
+function updateRangeButtons(container, activeRange) {
+  if (!container) {
+    return;
+  }
+
+  container.dataset.activeRange = activeRange;
+  container.querySelectorAll('.security-range-button').forEach((button) => {
+    const rangeKey = button.dataset.range;
+    const isActive = rangeKey === activeRange;
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    button.disabled = false;
+    button.classList.remove('loading');
+  });
+}
+
+function updateInfoBarContent(root, rangeKey, periodGain, dailyGain) {
+  const infoBar = root.querySelector('.security-info-bar');
+  if (!infoBar || !infoBar.parentElement) {
+    return;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = buildInfoBar(rangeKey, periodGain, dailyGain).trim();
+  const fresh = wrapper.firstElementChild;
+  if (!fresh) {
+    return;
+  }
+  infoBar.parentElement.replaceChild(fresh, infoBar);
+}
+
+const HISTORY_CHART_INSTANCES = new WeakMap();
+
+function getHistoryChartOptions(host, series, { currency } = {}) {
+  const measuredWidth = host.clientWidth || host.offsetWidth || 0;
+  const width = measuredWidth > 0 ? measuredWidth : 640;
+  const height = Math.min(Math.max(Math.floor(width * 0.55), 220), 420);
+  const safeCurrency = (currency || '').toUpperCase() || 'EUR';
+
+  return {
+    width,
+    height,
+    margin: { top: 16, right: 20, bottom: 32, left: 20 },
+    series,
+    yFormatter: formatPrice,
+    tooltipRenderer: ({ xFormatted, yFormatted }) => `
+      <div class="chart-tooltip-date">${xFormatted}</div>
+      <div class="chart-tooltip-value">${yFormatted}&nbsp;${safeCurrency}</div>
+    `,
+  };
+}
+
+function renderHistoryChart(host, series, options) {
+  if (!host || !Array.isArray(series) || series.length === 0) {
+    return;
+  }
+
+  const chartOptions = getHistoryChartOptions(host, series, options);
+  let chartContainer = HISTORY_CHART_INSTANCES.get(host);
+
+  if (!chartContainer || !host.contains(chartContainer)) {
+    host.innerHTML = '';
+    chartContainer = renderLineChart(host, chartOptions) || null;
+    if (chartContainer) {
+      HISTORY_CHART_INSTANCES.set(host, chartContainer);
+    }
+    return;
+  }
+
+  updateLineChart(chartContainer, chartOptions);
+}
+
+function updateHistoryPlaceholder(root, rangeKey, state, historySeries, options = {}) {
+  const placeholderContainer = root.querySelector('.security-detail-placeholder');
+  if (!placeholderContainer) {
+    return;
+  }
+
+  placeholderContainer.innerHTML = `
+    <h2>Historie</h2>
+    ${buildHistoryPlaceholder(rangeKey, state)}
+  `;
+
+  if (state?.status === 'loaded' && Array.isArray(historySeries) && historySeries.length) {
+    const host = placeholderContainer.querySelector('.history-chart');
+    if (host) {
+      requestAnimationFrame(() => {
+        renderHistoryChart(host, historySeries, options);
+      });
+    }
+  }
+}
+
+function scheduleRangeSetup({
+  root,
+  hass,
+  panelConfig,
+  securityUuid,
+  snapshot,
+  holdings,
+  initialRange,
+  initialHistory,
+  initialHistoryState,
+}) {
+  if (!root) {
+    return;
+  }
+
+  setTimeout(() => {
+    const rangeSelector = root.querySelector('.security-range-selector');
+    if (!rangeSelector) {
+      return;
+    }
+
+    const cache = ensureHistoryCache(securityUuid);
+    const shouldCacheInitial =
+      Array.isArray(initialHistory) && initialHistoryState?.status !== 'error';
+    if (shouldCacheInitial) {
+      cache.set(initialRange, initialHistory);
+    }
+
+    ensureLiveUpdateSubscription(securityUuid);
+
+    setActiveRange(securityUuid, initialRange);
+    updateRangeButtons(rangeSelector, initialRange);
+    if (initialHistoryState) {
+      updateHistoryPlaceholder(
+        root,
+        initialRange,
+        initialHistoryState,
+        initialHistory,
+        { currency: snapshot?.currency_code },
+      );
+    }
+
+    const handleRangeClick = async (rangeKey) => {
+      if (!rangeKey || rangeKey === getActiveRange(securityUuid)) {
+        return;
+      }
+
+      const button = rangeSelector.querySelector(
+        `.security-range-button[data-range="${rangeKey}"]`,
+      );
+      if (button) {
+        button.disabled = true;
+        button.classList.add('loading');
+      }
+
+      let historySeries = cache.get(rangeKey) || null;
+      let historyState = null;
+      if (!historySeries) {
+        try {
+          const rangeOptions = resolveRangeOptions(rangeKey);
+          const historyResponse = await fetchSecurityHistoryWS(
+            hass,
+            panelConfig,
+            securityUuid,
+            rangeOptions,
+          );
+          historySeries = normaliseHistorySeries(historyResponse?.prices);
+          cache.set(rangeKey, historySeries);
+          historyState = historySeries.length
+            ? { status: 'loaded' }
+            : { status: 'empty' };
+        } catch (error) {
+          console.error('Range-Wechsel: Historie konnte nicht geladen werden', error);
+          historySeries = [];
+          const message = normaliseHistoryError(error);
+          historyState = {
+            status: 'error',
+            message:
+              message ||
+              'Die historischen Daten konnten aufgrund eines Fehlers nicht geladen werden.',
+          };
+        }
+      } else {
+        historyState = historySeries.length
+          ? { status: 'loaded' }
+          : { status: 'empty' };
+      }
+
+      const lastClose = historySeries.length
+        ? historySeries[historySeries.length - 1].close
+        : snapshot?.last_price_native;
+      const activeFxRate = deriveFxRate(snapshot, lastClose);
+      const { periodGain, dailyGain } = computeGainValues(
+        historySeries,
+        holdings,
+        activeFxRate,
+      );
+
+      setActiveRange(securityUuid, rangeKey);
+      updateRangeButtons(rangeSelector, rangeKey);
+      updateInfoBarContent(root, rangeKey, periodGain, dailyGain);
+      updateHistoryPlaceholder(
+        root,
+        rangeKey,
+        historyState,
+        historySeries,
+        { currency: snapshot?.currency_code },
+      );
+    };
+
+    rangeSelector.addEventListener('click', (event) => {
+      const button = event.target.closest('.security-range-button');
+      if (!button || button.disabled) {
+        return;
+      }
+      const { range } = button.dataset;
+      handleRangeClick(range);
+    });
+  }, 0);
+}
+
+export function registerSecurityDetailTab({ setSecurityDetailTabFactory }) {
+  if (typeof setSecurityDetailTabFactory !== 'function') {
+    console.error('registerSecurityDetailTab: Ungültige Factory-Funktion übergeben');
+    return;
+  }
+
+  setSecurityDetailTabFactory((securityUuid) => ({
+    title: 'Wertpapier',
+    render: (root, hass, panelConfig) => renderSecurityDetail(root, hass, panelConfig, securityUuid),
+    cleanup: () => cleanupSecurityDetailState(securityUuid),
+  }));
+}


### PR DESCRIPTION
## Summary
- mirror the existing dashboard JavaScript modules into a new `src/` TypeScript source tree with no-check headers to preserve behaviour
- mark the frontend TypeScript migration checklist item for creating the mirrored source tree as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ddc8ea2c8330bed7e6481ebe1410