### PR TITLE
Add TypeScript re-export barrels for dashboard modules

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -29,7 +29,7 @@
       - Dateien: `src/dashboard.ts`, `src/panel.ts` (neu)
       - Abschnitt: Exporte & Initialisierung
       - Ziel: Spiegele Verhalten von `dashboard.js` und `panel.js`, sodass Bundler einen konsistenten Einstieg hat.
-   c) [ ] Ergänze Re-Exports für bestehende Tabs und Utilities
+   c) [x] Ergänze Re-Exports für bestehende Tabs und Utilities
       - Dateien: `src/dashboard/index.ts`, `src/dashboard/tabs/*.ts`, `src/data/*.ts`
       - Abschnitt: Modul-Exporte
       - Ziel: Bewahre bestehende öffentliche APIs, damit importierende Module unverändert funktionieren.

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Barrel module exposing the legacy dashboard surface for TypeScript sources.
+ *
+ * Keeps tab controllers and data utilities reachable under a single import,
+ * mirroring the public API provided by the historical JavaScript modules.
+ */
+export * from '../dashboard';
+export * from '../tabs/overview';
+export * from '../tabs/security_detail';
+export * from '../data/api';
+export * from '../data/updateConfigsWS';
+export { addSwipeEvents, goToTab } from '../interaction/tab_control';

--- a/src/dashboard/tabs/overview.ts
+++ b/src/dashboard/tabs/overview.ts
@@ -1,0 +1,4 @@
+/**
+ * Re-export for the overview tab to keep backwards compatible import paths.
+ */
+export * from '../../tabs/overview';

--- a/src/dashboard/tabs/security_detail.ts
+++ b/src/dashboard/tabs/security_detail.ts
@@ -1,0 +1,4 @@
+/**
+ * Re-export for the security detail tab matching the legacy module layout.
+ */
+export * from '../../tabs/security_detail';

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Barrel module exposing data-related helpers from the legacy dashboard.
+ */
+export * from './api';
+export * from './updateConfigsWS';

--- a/src/data/updateConfigsWS.ts
+++ b/src/data/updateConfigsWS.ts
@@ -4,8 +4,8 @@
  * Live update handlers mirrored from the legacy websocket client.
  */
 
-import { makeTable } from '../content/elements.js';
-import { sortTableRows } from '../content/elements.js'; // NEU: generische Sortier-Utility
+import { makeTable } from '../content/elements';
+import { sortTableRows } from '../content/elements'; // NEU: generische Sortier-Utility
 
 const PENDING_RETRY_INTERVAL = 500;
 const PENDING_MAX_ATTEMPTS = 10;

--- a/src/tabs/overview.ts
+++ b/src/tabs/overview.ts
@@ -4,10 +4,22 @@
  * Overview tab renderer copied for the TypeScript source tree.
  */
 
-import { createHeaderCard, makeTable, formatNumber, formatGain, formatGainPct, formatValue } from '../content/elements.js';
-import { openSecurityDetail } from '../dashboard.module.js';
-import { fetchAccountsWS, fetchLastFileUpdateWS, fetchPortfoliosWS, fetchPortfolioPositionsWS } from '../data/api.js';
-import { flushPendingPositions, flushAllPendingPositions } from '../data/updateConfigsWS.js';
+import {
+  createHeaderCard,
+  makeTable,
+  formatNumber,
+  formatGain,
+  formatGainPct,
+  formatValue,
+} from '../content/elements';
+import { openSecurityDetail } from '../dashboard';
+import {
+  fetchAccountsWS,
+  fetchLastFileUpdateWS,
+  fetchPortfoliosWS,
+  fetchPortfolioPositionsWS,
+} from '../data/api';
+import { flushPendingPositions, flushAllPendingPositions } from '../data/updateConfigsWS';
 
 // === Modul-weiter State für Expand/Collapse & Lazy Load ===
 // On-Demand Aggregation liefert frische Portfolio-Werte; nur Positionen bleiben Lazy-Loaded.

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -11,9 +11,9 @@
  * exposes a helper to register the descriptor factory with the
  * dashboard controller.
  */
-import { createHeaderCard, formatNumber, formatGain } from '../content/elements.js';
-import { renderLineChart, updateLineChart } from '../content/charting.js';
-import { fetchSecuritySnapshotWS, fetchSecurityHistoryWS } from '../data/api.js';
+import { createHeaderCard, formatNumber, formatGain } from '../content/elements';
+import { renderLineChart, updateLineChart } from '../content/charting';
+import { fetchSecuritySnapshotWS, fetchSecurityHistoryWS } from '../data/api';
 
 const HOLDINGS_FRACTION_DIGITS = { min: 0, max: 6 };
 const PRICE_FRACTION_DIGITS = { min: 2, max: 4 };


### PR DESCRIPTION
## Summary
- add TypeScript barrel modules that mirror the legacy dashboard API surface
- adjust tab and data module imports to use extensionless paths compatible with the TypeScript build
- update the migration checklist to reflect the completed re-export work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0e56e90448330b53b742de2792249