### PR TITLE
Add Home Assistant ambient type declarations

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -35,7 +35,7 @@
       - Ziel: Bewahre bestehende öffentliche APIs, damit importierende Module unverändert funktionieren.
 
 3. Typisierungsgrundlagen schaffen
-   a) [ ] Definiere Home Assistant spezifische Typ-Deklarationen
+   a) [x] Definiere Home Assistant spezifische Typ-Deklarationen
       - Datei: `src/types/home-assistant.d.ts` (neu)
       - Abschnitt: Schnittstellen für `hass`, Panels, WebSocket-Strukturen
       - Ziel: Statische Typen für häufig genutzte Objekte bereitstellen und unbekannte Felder über optionale Properties erlauben.

--- a/src/types/home-assistant.d.ts
+++ b/src/types/home-assistant.d.ts
@@ -1,0 +1,142 @@
+/**
+ * Ambient Home Assistant type declarations for the PP Reader dashboard.
+ * These interfaces cover the subset of the frontend runtime that is
+ * consumed by the portfolio panel while keeping unknown fields flexible.
+ */
+
+export type HassServiceTarget = Record<string, unknown>;
+
+export interface HassContext {
+  id: string;
+  user_id?: string | null;
+  parent_id?: string | null;
+}
+
+export interface HassEntityState {
+  entity_id: string;
+  state: string;
+  attributes: Record<string, unknown>;
+  last_changed: string;
+  last_updated: string;
+  context?: HassContext;
+  [key: string]: unknown;
+}
+
+export interface HassLocale {
+  language: string;
+  number_format?: string;
+  time_format?: '12' | '24';
+  temperature_unit?: string;
+  country?: string;
+  [key: string]: unknown;
+}
+
+export interface HassPanelCustomConfig {
+  module_url?: string;
+  embed_iframe?: boolean;
+  trust_external?: boolean;
+  require_admin?: boolean;
+  config?: {
+    entry_id?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface HassPanelOptions {
+  entry_id?: string;
+  _panel_custom?: HassPanelCustomConfig;
+  [key: string]: unknown;
+}
+
+export interface HassPanel {
+  component_name?: string;
+  url_path?: string;
+  title?: string;
+  icon?: string;
+  panel_icon?: string;
+  webcomponent_name?: string;
+  config?: HassPanelOptions;
+  require_admin?: boolean;
+  js_url?: string;
+  [key: string]: unknown;
+}
+
+export type HassPanels = Record<string, HassPanel>;
+
+export interface HassPanelInfo extends HassPanel {
+  url_path: string;
+}
+
+export interface HassRoute {
+  path: string;
+  prefix?: string;
+  [key: string]: unknown;
+}
+
+export interface HassUser {
+  id: string;
+  name: string;
+  is_owner?: boolean;
+  is_admin?: boolean;
+  [key: string]: unknown;
+}
+
+export interface HassEvent<T = unknown> {
+  origin: 'LOCAL' | 'REMOTE' | 'CLOUD' | string;
+  time_fired: string;
+  event_type: string;
+  context?: HassContext;
+  data: T;
+}
+
+export interface HassWebSocketMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type HassUnsubscribe = () => void;
+
+export interface HassWebSocketConnection {
+  sendMessage(message: HassWebSocketMessage): void;
+  sendMessagePromise<T = unknown>(message: HassWebSocketMessage): Promise<T>;
+  subscribeMessage<T = unknown>(
+    callback: (response: T) => void,
+    message: HassWebSocketMessage
+  ): Promise<HassUnsubscribe>;
+  subscribeEvents<T = unknown>(
+    callback: (event: HassEvent<T>) => void,
+    eventType?: string
+  ): Promise<HassUnsubscribe>;
+  [key: string]: unknown;
+}
+
+export interface HomeAssistant {
+  connection: HassWebSocketConnection;
+  panels?: HassPanels;
+  panelUrl?: string;
+  callService?: (
+    domain: string,
+    service: string,
+    serviceData?: Record<string, unknown>,
+    target?: HassServiceTarget
+  ) => Promise<void> | void;
+  callApi?: <T = unknown>(method: string, path: string, parameters?: unknown) => Promise<T>;
+  callWS?: <T = unknown>(message: HassWebSocketMessage) => Promise<T>;
+  states?: Record<string, HassEntityState>;
+  locale?: HassLocale;
+  language?: string;
+  user?: HassUser;
+  formatEntityState?: (state: HassEntityState) => string;
+  formatDateTime?: (date: Date, options?: Intl.DateTimeFormatOptions) => string;
+  formatNumber?: (value: number, options?: Intl.NumberFormatOptions) => string;
+  [key: string]: unknown;
+}
+
+export interface HassPanelElement extends HTMLElement {
+  hass?: HomeAssistant;
+  panel?: HassPanel;
+  route?: HassRoute;
+  narrow?: boolean;
+  [key: string]: unknown;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
   },
   "include": [
     "src/**/*.ts",
-    "src/**/*.tsx"
+    "src/**/*.tsx",
+    "src/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- add ambient type declarations that model Home Assistant panels, websocket APIs, and hass helpers used by the dashboard
- include the new declaration files in the TypeScript compiler configuration
- mark the TypeScript migration checklist item for hass typings as complete

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0e820242c8330afc2b2e6799f064c