### PR TITLE
Add TypeScript global declarations for PP Reader window extensions

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -39,7 +39,7 @@
       - Datei: `src/types/home-assistant.d.ts` (neu)
       - Abschnitt: Schnittstellen für `hass`, Panels, WebSocket-Strukturen
       - Ziel: Statische Typen für häufig genutzte Objekte bereitstellen und unbekannte Felder über optionale Properties erlauben.
-   b) [ ] Ergänze globale Fenstererweiterungen
+   b) [x] Ergänze globale Fenstererweiterungen
       - Datei: `src/types/global.d.ts` (neu)
       - Abschnitt: `declare global { interface Window { ... } }`
       - Ziel: Formalisiere bisherige `window.__ppReader...` Zugriffe für TypeScript-Striktheit.

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,67 @@
+/**
+ * Global PP Reader dashboard declarations for window and DOM extensions.
+ * Provides typed access to legacy globals during the TypeScript migration.
+ */
+import type {
+  flushAllPendingPositions,
+  flushPendingPositions,
+  reapplyPositionsSort,
+} from '../data/updateConfigsWS';
+import type {
+  attachPortfolioPositionsSorting,
+  attachSecurityDetailListener,
+  getSecurityPositionsFromCache,
+  getSecuritySnapshotFromCache,
+  updatePortfolioFooterFromDom,
+} from '../tabs/overview';
+
+type PortfolioPosition = Record<string, unknown>;
+
+type GainPctMetadataApplier = (table: HTMLTableElement) => void;
+type RenderPositionsTable = (positions: PortfolioPosition[]) => string;
+
+type PendingPortfolioUpdate = {
+  positions: PortfolioPosition[];
+  error?: unknown;
+};
+
+type PendingRetryMeta = {
+  attempts: number;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+interface PortfolioPositionsCache extends Map<string, PortfolioPosition[]> {
+  getSecuritySnapshot?: typeof getSecuritySnapshotFromCache;
+  getSecurityPositions?: typeof getSecurityPositionsFromCache;
+}
+
+declare global {
+  interface Window {
+    __ppReaderDashboardElements?: Set<HTMLElement>;
+    __ppReaderPanelHosts?: Set<HTMLElement>;
+    __ppReaderPortfolioPositionsCache?: PortfolioPositionsCache;
+    __ppReaderGetSecuritySnapshotFromCache?: typeof getSecuritySnapshotFromCache;
+    __ppReaderGetSecurityPositionsFromCache?: typeof getSecurityPositionsFromCache;
+    __ppReaderApplyGainPctMetadata?: GainPctMetadataApplier;
+    __ppReaderRenderPositionsTable?: RenderPositionsTable;
+    __ppReaderAttachSecurityDetailListener?: typeof attachSecurityDetailListener;
+    __ppReaderAttachPortfolioPositionsSorting?: typeof attachPortfolioPositionsSorting;
+    __ppReaderPendingPositions?: Map<string, PendingPortfolioUpdate>;
+    __ppReaderPendingRetryMeta?: Map<string, PendingRetryMeta>;
+    __ppReaderFlushPendingPositions?: typeof flushPendingPositions;
+    __ppReaderFlushAllPendingPositions?: typeof flushAllPendingPositions;
+    __ppReaderUpdatePortfolioFooter?: typeof updatePortfolioFooterFromDom;
+    __ppReaderReapplyPositionsSort?: typeof reapplyPositionsSort;
+  }
+
+  interface HTMLElement {
+    __ppReaderSecurityClickBound?: boolean;
+    __ppReaderSortingBound?: boolean;
+    __ppReaderPortfolioToggleBound?: boolean;
+    __ppReaderPortfolioFallbackBound?: boolean;
+    __ppReaderAttachToken?: number;
+    __ppReaderAttachInProgress?: boolean;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add TypeScript declaration file for PP Reader window globals and DOM markers used by the dashboard
- update the migration checklist to reflect the completed global declaration task

## Testing
- not run (type-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e0eb4b84908330ac810ce9c9f0d16f