### PR TITLE
Add build helper to update dashboard module specifier

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -53,7 +53,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/js/dashboard.module.js`
       - Abschnitt: `export * from` Zeile
       - Ziel: Lass den Build-Prozess Hash/Version-Parameter automatisch setzen.
-   b) [ ] Ergänze Post-Build-Skript zur Aktualisierung des Modul-Pfads
+   b) [x] Ergänze Post-Build-Skript zur Aktualisierung des Modul-Pfads
       - Datei: `scripts/update_dashboard_module.mjs` (neu) oder Bundler-Plugin
       - Abschnitt: Skript-Hauptfunktion
       - Ziel: Schreibt nach jedem Build den neuen Dateinamen/Hash in `dashboard.module.js`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "vite build && npm run build:types",
+    "build": "vite build && node ./scripts/update_dashboard_module.mjs && npm run build:types",
     "dev": "vite dev",
     "typecheck": "tsc --noEmit",
     "build:types": "tsc -p tsconfig.json",

--- a/scripts/update_dashboard_module.mjs
+++ b/scripts/update_dashboard_module.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Update the dashboard module re-export to point to the latest hashed bundle.
+ *
+ * The TypeScript build emits files such as `dashboard.<hash>.js` into the
+ * Home Assistant www directory. This script replaces the placeholder specifier
+ * in `dashboard.module.js` with the most recently generated bundle so Home
+ * Assistant always loads the fresh asset without manual edits.
+ */
+import { promises as fs } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HASHED_ENTRY_PATTERN = /^dashboard\.[a-f0-9]+\.js$/i;
+const MODULE_EXPORT_PATTERN = /export \* from ['"](?<specifier>.+?)['"];?/;
+
+async function findLatestBundle(directory) {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const candidates = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && HASHED_ENTRY_PATTERN.test(entry.name))
+      .map(async (entry) => {
+        const fullPath = resolve(directory, entry.name);
+        const stats = await fs.stat(fullPath);
+        return { name: entry.name, mtimeMs: stats.mtimeMs };
+      }),
+  );
+
+  if (!candidates.length) {
+    return null;
+  }
+
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates[0].name;
+}
+
+async function updateModule(modulePath, bundleSpecifier) {
+  const contents = await fs.readFile(modulePath, 'utf8');
+
+  if (!MODULE_EXPORT_PATTERN.test(contents)) {
+    throw new Error(`dashboard.module.js does not contain an export line to rewrite at ${modulePath}`);
+  }
+
+  const replacementLine = `export * from './${bundleSpecifier}';`;
+  let updated = contents.replace(MODULE_EXPORT_PATTERN, replacementLine);
+
+  if (updated === contents) {
+    return false;
+  }
+
+  await fs.writeFile(modulePath, `${updated.trimEnd()}\n`, 'utf8');
+  return true;
+}
+
+async function main() {
+  const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+  const projectRoot = resolve(scriptDirectory, '..');
+  const bundleDirectory = resolve(
+    projectRoot,
+    'custom_components/pp_reader/www/pp_reader_dashboard/js',
+  );
+  const modulePath = resolve(bundleDirectory, 'dashboard.module.js');
+
+  const latestBundle = await findLatestBundle(bundleDirectory);
+
+  if (!latestBundle) {
+    console.warn(
+      'update_dashboard_module: kein gebundeltes Dashboard gefunden, behalte Platzhalter bei.',
+    );
+    return;
+  }
+
+  const updated = await updateModule(modulePath, latestBundle);
+
+  if (updated) {
+    console.log(
+      `update_dashboard_module: Aktualisierter Modul-Spezifier auf ${latestBundle}.`,
+    );
+  } else {
+    console.log('update_dashboard_module: Modul-Spezifier war bereits aktuell.');
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('update_dashboard_module: Fehler beim Aktualisieren des Moduls:', error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a post-build Node script that rewrites dashboard.module.js to the newest hashed dashboard bundle
- invoke the updater automatically as part of npm run build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0f3722f908330831aba7c8d6c11ea