### PR TITLE
Add fallback loader for dashboard bundle in panel

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -57,7 +57,7 @@
       - Datei: `scripts/update_dashboard_module.mjs` (neu) oder Bundler-Plugin
       - Abschnitt: Skript-Hauptfunktion
       - Ziel: Schreibt nach jedem Build den neuen Dateinamen/Hash in `dashboard.module.js`.
-   c) [ ] Stelle sicher, dass `panel.js` weiterhin funktional bleibt
+   c) [x] Stelle sicher, dass `panel.js` weiterhin funktional bleibt
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/panel.js`
       - Abschnitt: Importstatement & Initialisierung
       - Ziel: Prüfe und passe ggf. den Importpfad auf das bundlergenerierte Modul an, ohne öffentliches API zu ändern.

--- a/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
@@ -1,4 +1,30 @@
-import './js/dashboard.module.js';
+// Die Panel-Logik muss das Dashboard-Modul laden, bevor der Custom Element Code
+// ausgeführt wird. Wir nutzen Top-Level-Await, um zuerst das gebaute Bundle zu
+// importieren und bei Bedarf auf die Legacy-Datei zurückzufallen.
+const DASHBOARD_MODULE_SPECIFIER = './js/dashboard.module.js';
+const LEGACY_DASHBOARD_SPECIFIER = './js/dashboard.js';
+
+async function loadDashboardModule() {
+  try {
+    await import(DASHBOARD_MODULE_SPECIFIER);
+  } catch (error) {
+    console.warn(
+      '[pp_reader] Konnte gebundeltes Dashboard nicht laden, versuche Legacy-Fallback.',
+      error,
+    );
+    try {
+      await import(LEGACY_DASHBOARD_SPECIFIER);
+    } catch (fallbackError) {
+      console.error(
+        '[pp_reader] Fallback dashboard.js konnte ebenfalls nicht geladen werden.',
+        fallbackError,
+      );
+      throw fallbackError;
+    }
+  }
+}
+
+await loadDashboardModule();
 
 const ASSET_BASE_URL = new URL('./', import.meta.url);
 


### PR DESCRIPTION
## Summary
- ensure the Home Assistant panel loads the bundled dashboard module with a top-level await and falls back to the legacy asset when necessary
- mark the frontend TypeScript migration checklist item for panel.js as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0f6b2f8a48330a40203c9fb551036