### PR TITLE
feat: add typed websocket client helpers

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -67,7 +67,7 @@
       - Ziel: Verlasse ausschließlich generierte Artefakte im `js/` Verzeichnis.
 
 5. TypeScript-Refactor & Striktheitsverbesserungen
-   a) [ ] Portiere WebSocket-API mit starken Typen
+   a) [x] Portiere WebSocket-API mit starken Typen
       - Datei: `src/data/api.ts`
       - Abschnitt: Anfrage-/Antwortfabriken
       - Ziel: Ersetze dynamische `any` Checks durch typed Interfaces für Nachrichten und `entry_id` Handling.

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,168 +1,343 @@
-// @ts-nocheck
-
 /**
  * Home Assistant websocket API helpers carried over for TypeScript migration.
  */
 
-function deriveEntryId(hass, panelConfig) {
-  // Direkt gesetzte einfache Variante (neuer Panelspeicher)
-  let entry_id = panelConfig?.config?.entry_id;
+import type { HomeAssistant } from "../types/home-assistant";
 
-  // Neu: Home Assistant liefert den entry_id-Wert inzwischen auch auf Root-Ebene
-  // des panelConfig-Objekts. Ohne diesen Fallback konnten wir in seltenen Fällen
-  // keinen entry_id bestimmen (z.B. wenn hass.panels noch nicht gefüllt war),
-  // wodurch sämtliche Websocket-Aufrufe mit "fehlendes hass oder entry_id" brachen.
-  if (!entry_id) {
-    entry_id = panelConfig?.entry_id;
-  }
+interface PanelConfigLike {
+  entry_id?: string | null;
+  config?: {
+    entry_id?: string | null;
+    _panel_custom?: {
+      config?: {
+        entry_id?: string | null;
+      } | null;
+    } | null;
+  } | null;
+  webcomponent_name?: string | null;
+  [key: string]: unknown;
+}
 
-  // Legacy verschachtelte Struktur (panel_custom)
-  if (!entry_id) {
-    entry_id = panelConfig?.config?._panel_custom?.config?.entry_id;
-  }
+export interface AccountSummary {
+  name?: string | null;
+  currency_code?: string | null;
+  orig_balance?: number | null;
+  balance?: number | null;
+  fx_unavailable?: boolean;
+  [key: string]: unknown;
+}
 
-  // Fallback: aus hass.panels suchen
-  if (!entry_id && hass?.panels) {
+export interface PortfolioSummary {
+  uuid?: string | null;
+  name?: string | null;
+  current_value?: number | null;
+  purchase_sum?: number | null;
+  position_count?: number | null;
+  [key: string]: unknown;
+}
+
+export interface DashboardDataResponse {
+  accounts: AccountSummary[];
+  portfolios: PortfolioSummary[];
+  last_file_update?: string | null;
+  transactions: unknown[];
+  [key: string]: unknown;
+}
+
+export interface AccountsResponse {
+  accounts: AccountSummary[];
+  [key: string]: unknown;
+}
+
+export interface PortfoliosResponse {
+  portfolios: PortfolioSummary[];
+  [key: string]: unknown;
+}
+
+export interface PortfolioPosition {
+  security_uuid: string;
+  name: string;
+  current_holdings: number;
+  purchase_value: number;
+  current_value: number;
+  gain_abs: number;
+  gain_pct: number;
+  [key: string]: unknown;
+}
+
+export interface PortfolioPositionsResponse {
+  portfolio_uuid: string;
+  positions: PortfolioPosition[];
+  error?: string;
+  [key: string]: unknown;
+}
+
+export interface SecuritySnapshotResponse {
+  security_uuid: string;
+  snapshot: {
+    name?: string;
+    currency_code?: string;
+    total_holdings?: number;
+    last_price_native?: number | null;
+    last_price_eur?: number;
+    market_value_eur?: number;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface SecurityHistoryPoint {
+  date: number;
+  close: number;
+  [key: string]: unknown;
+}
+
+export interface SecurityHistoryResponse {
+  security_uuid: string;
+  prices: SecurityHistoryPoint[];
+  start_date?: number | null;
+  end_date?: number | null;
+  [key: string]: unknown;
+}
+
+export interface LastFileUpdateResponse {
+  last_file_update?: string | null;
+  [key: string]: unknown;
+}
+
+export interface SecurityHistoryOptions {
+  startDate?: number | null;
+  endDate?: number | null;
+  start_date?: number | null;
+  end_date?: number | null;
+  [key: string]: unknown;
+}
+
+interface SecurityHistoryRequestPayload {
+  type: "pp_reader/get_security_history";
+  entry_id: string;
+  security_uuid: string;
+  start_date?: number | null;
+  end_date?: number | null;
+  [key: string]: string | number | null | undefined;
+}
+
+function deriveEntryId(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+): string | undefined {
+  let entryId =
+    panelConfig?.config?.entry_id ??
+    panelConfig?.entry_id ??
+    panelConfig?.config?._panel_custom?.config?.entry_id ??
+    undefined;
+
+  if (!entryId && hass?.panels) {
+    const panels = hass.panels;
     const candidate =
-      hass.panels.ppreader ||
-      hass.panels.pp_reader ||
-      Object.values(hass.panels).find(p => p?.webcomponent_name === 'pp-reader-panel');
-    entry_id =
-      candidate?.config?.entry_id ||
-      candidate?.config?._panel_custom?.config?.entry_id;
+      (panels.ppreader as PanelConfigLike | undefined) ??
+      (panels.pp_reader as PanelConfigLike | undefined) ??
+      (Object.values(panels).find(
+        panel => (panel as PanelConfigLike | undefined)?.webcomponent_name === "pp-reader-panel",
+      ) as PanelConfigLike | undefined);
+
+    entryId =
+      candidate?.config?.entry_id ??
+      candidate?.entry_id ??
+      candidate?.config?._panel_custom?.config?.entry_id ??
+      undefined;
   }
 
-  return entry_id;
+  return entryId ?? undefined;
 }
 
 // Export für andere Module (Dashboard/Event-Filter)
-export function getEntryId(hass, panelConfig) {
+export function getEntryId(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+): string | undefined {
   return deriveEntryId(hass, panelConfig);
 }
 
 // Dashboard Data
-export async function fetchDashboardDataWS(hass, panelConfig) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(`fetchDashboardDataWS: fehlendes hass oder entry_id (${entry_id})`);
+export async function fetchDashboardDataWS(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+): Promise<DashboardDataResponse> {
+  if (!hass) {
+    throw new Error("fetchDashboardDataWS: fehlendes hass");
   }
-  return await hass.connection.sendMessagePromise({
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchDashboardDataWS: fehlendes entry_id");
+  }
+
+  return hass.connection.sendMessagePromise<DashboardDataResponse>({
     type: "pp_reader/get_dashboard_data",
-    entry_id,
+    entry_id: entryId,
   });
 }
 
 // Accounts
-export async function fetchAccountsWS(hass, panelConfig) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(`fetchAccountsWS: fehlendes hass oder entry_id (${entry_id})`);
+export async function fetchAccountsWS(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+): Promise<AccountsResponse> {
+  if (!hass) {
+    throw new Error("fetchAccountsWS: fehlendes hass");
   }
-  return await hass.connection.sendMessagePromise({
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchAccountsWS: fehlendes entry_id");
+  }
+
+  return hass.connection.sendMessagePromise<AccountsResponse>({
     type: "pp_reader/get_accounts",
-    entry_id,
+    entry_id: entryId,
   });
 }
 
 // Last file update
-export async function fetchLastFileUpdateWS(hass, panelConfig) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(`fetchLastFileUpdateWS: fehlendes hass oder entry_id (${entry_id})`);
+export async function fetchLastFileUpdateWS(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+): Promise<string> {
+  if (!hass) {
+    throw new Error("fetchLastFileUpdateWS: fehlendes hass");
   }
-  const response = await hass.connection.sendMessagePromise({
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchLastFileUpdateWS: fehlendes entry_id");
+  }
+
+  const response = await hass.connection.sendMessagePromise<
+    LastFileUpdateResponse | string
+  >({
     type: "pp_reader/get_last_file_update",
-    entry_id,
+    entry_id: entryId,
   });
-  return response?.last_file_update || response || '';
+
+  if (typeof response === "string") {
+    return response;
+  }
+
+  const lastFileUpdate = response?.last_file_update;
+  return typeof lastFileUpdate === "string" ? lastFileUpdate : "";
 }
 
 // Portfolios
-export async function fetchPortfoliosWS(hass, panelConfig) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(`fetchPortfoliosWS: fehlendes hass oder entry_id (${entry_id})`);
+export async function fetchPortfoliosWS(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+): Promise<PortfoliosResponse> {
+  if (!hass) {
+    throw new Error("fetchPortfoliosWS: fehlendes hass");
   }
-  return await hass.connection.sendMessagePromise({
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchPortfoliosWS: fehlendes entry_id");
+  }
+
+  return hass.connection.sendMessagePromise<PortfoliosResponse>({
     type: "pp_reader/get_portfolio_data",
-    entry_id,
+    entry_id: entryId,
   });
 }
 
 // Positions (lazy)
-export async function fetchPortfolioPositionsWS(hass, panelConfig, portfolio_uuid) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(`fetchPortfolioPositionsWS: fehlendes hass oder entry_id (${entry_id})`);
+export async function fetchPortfolioPositionsWS(
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+  portfolioUuid: string | null | undefined,
+): Promise<PortfolioPositionsResponse> {
+  if (!hass) {
+    throw new Error("fetchPortfolioPositionsWS: fehlendes hass");
   }
-  if (!portfolio_uuid) {
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchPortfolioPositionsWS: fehlendes entry_id");
+  }
+
+  if (!portfolioUuid) {
     throw new Error("fetchPortfolioPositionsWS: fehlendes portfolio_uuid");
   }
-  return await hass.connection.sendMessagePromise({
+
+  return hass.connection.sendMessagePromise<PortfolioPositionsResponse>({
     type: "pp_reader/get_portfolio_positions",
-    entry_id,
-    portfolio_uuid,
+    entry_id: entryId,
+    portfolio_uuid: portfolioUuid,
   });
 }
 
 // Security snapshot for detail tab
 export async function fetchSecuritySnapshotWS(
-  hass,
-  panelConfig,
-  securityUuid,
-) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(
-      `fetchSecuritySnapshotWS: fehlendes hass oder entry_id (${entry_id})`,
-    );
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+  securityUuid: string | null | undefined,
+): Promise<SecuritySnapshotResponse> {
+  if (!hass) {
+    throw new Error("fetchSecuritySnapshotWS: fehlendes hass");
   }
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchSecuritySnapshotWS: fehlendes entry_id");
+  }
+
   if (!securityUuid) {
     throw new Error("fetchSecuritySnapshotWS: fehlendes securityUuid");
   }
 
-  return await hass.connection.sendMessagePromise({
+  return hass.connection.sendMessagePromise<SecuritySnapshotResponse>({
     type: "pp_reader/get_security_snapshot",
-    entry_id,
+    entry_id: entryId,
     security_uuid: securityUuid,
   });
 }
 
 // Historical prices for detail tab charting
 export async function fetchSecurityHistoryWS(
-  hass,
-  panelConfig,
-  securityUuid,
-  options = {},
-) {
-  const entry_id = deriveEntryId(hass, panelConfig);
-  if (!hass || !entry_id) {
-    throw new Error(
-      `fetchSecurityHistoryWS: fehlendes hass oder entry_id (${entry_id})`,
-    );
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+  securityUuid: string | null | undefined,
+  options: SecurityHistoryOptions | null | undefined = {},
+): Promise<SecurityHistoryResponse> {
+  if (!hass) {
+    throw new Error("fetchSecurityHistoryWS: fehlendes hass");
   }
+
+  const entryId = deriveEntryId(hass, panelConfig);
+  if (!entryId) {
+    throw new Error("fetchSecurityHistoryWS: fehlendes entry_id");
+  }
+
   if (!securityUuid) {
     throw new Error("fetchSecurityHistoryWS: fehlendes securityUuid");
   }
 
-  const payload = {
+  const payload: SecurityHistoryRequestPayload = {
     type: "pp_reader/get_security_history",
-    entry_id,
+    entry_id: entryId,
     security_uuid: securityUuid,
   };
 
-  const { startDate, endDate, start_date: start_date_raw, end_date: end_date_raw } =
+  const { startDate, endDate, start_date: startDateRaw, end_date: endDateRaw } =
     options || {};
 
-  const resolvedStart = startDate ?? start_date_raw;
+  const resolvedStart = startDate ?? startDateRaw;
   if (resolvedStart !== undefined && resolvedStart !== null) {
     payload.start_date = resolvedStart;
   }
 
-  const resolvedEnd = endDate ?? end_date_raw;
+  const resolvedEnd = endDate ?? endDateRaw;
   if (resolvedEnd !== undefined && resolvedEnd !== null) {
     payload.end_date = resolvedEnd;
   }
 
-  return await hass.connection.sendMessagePromise(payload);
+  return hass.connection.sendMessagePromise<SecurityHistoryResponse>(payload);
 }


### PR DESCRIPTION
## Summary
- add explicit interfaces for websocket payloads and responses in src/data/api.ts
- tighten entry_id derivation to use typed Home Assistant panel metadata
- mark the TypeScript migration checklist item for websocket typing as complete

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0fbb89ee08330b392c865ec0a84f2