### PR TITLE
Add strict typing to update handlers and DOM utilities

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -71,7 +71,7 @@
       - Datei: `src/data/api.ts`
       - Abschnitt: Anfrage-/Antwortfabriken
       - Ziel: Ersetze dynamische `any` Checks durch typed Interfaces für Nachrichten und `entry_id` Handling.
-   b) [ ] Typisiere Update-Handler und DOM-Utilities
+   b) [x] Typisiere Update-Handler und DOM-Utilities
       - Datei: `src/data/updateConfigsWS.ts`, `src/content/elements.ts`
       - Abschnitt: Fenster-Caches, DOM-Manipulationen
       - Ziel: Nutze strukturierte Interfaces und vermeide untypisierte `window`-Zugriffe.


### PR DESCRIPTION
## Summary
- tighten the content rendering helpers with explicit table types and typed sorting
- port the websocket update handlers and DOM utilities to strict TypeScript, covering caches, retries, and dispatch helpers
- mark the TypeScript migration checklist item for the update handlers as complete

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0fe2aaf788330a6a470ddb5c5d1e3