### PR TITLE
Add shared tab typings for dashboard modules

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -75,7 +75,7 @@
       - Datei: `src/data/updateConfigsWS.ts`, `src/content/elements.ts`
       - Abschnitt: Fenster-Caches, DOM-Manipulationen
       - Ziel: Nutze strukturierte Interfaces und vermeide untypisierte `window`-Zugriffe.
-   c) [ ] Etabliere gemeinsame Tab-Typen und API-Exports
+   c) [x] Etabliere gemeinsame Tab-Typen und API-Exports
       - Dateien: `src/tabs/types.ts` (neu), `src/data/api.ts`, `src/data/updateConfigsWS.ts`
       - Abschnitt: Panel-Konfiguration, Tab-Descriptoren, Event-Payloads
       - Ziel: Liefere wiederverwendbare Typdefinitionen für Panel-/Tab-Kontext (inkl. `PanelConfigLike`, History-Ranges, Security-Snapshots) und exportiere das Event-Payload für `pp-reader:portfolio-positions-updated`.

--- a/src/dashboard/index.ts
+++ b/src/dashboard/index.ts
@@ -7,6 +7,7 @@
 export * from '../dashboard';
 export * from '../tabs/overview';
 export * from '../tabs/security_detail';
+export * from '../tabs/types';
 export * from '../data/api';
 export * from '../data/updateConfigsWS';
 export { addSwipeEvents, goToTab } from '../interaction/tab_control';

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -2,21 +2,8 @@
  * Home Assistant websocket API helpers carried over for TypeScript migration.
  */
 
+import type { PanelConfigLike } from "../tabs/types";
 import type { HomeAssistant } from "../types/home-assistant";
-
-interface PanelConfigLike {
-  entry_id?: string | null;
-  config?: {
-    entry_id?: string | null;
-    _panel_custom?: {
-      config?: {
-        entry_id?: string | null;
-      } | null;
-    } | null;
-  } | null;
-  webcomponent_name?: string | null;
-  [key: string]: unknown;
-}
 
 export interface AccountSummary {
   name?: string | null;

--- a/src/data/updateConfigsWS.ts
+++ b/src/data/updateConfigsWS.ts
@@ -5,7 +5,10 @@
 import { makeTable } from '../content/elements';
 import { sortTableRows } from '../content/elements'; // NEU: generische Sortier-Utility
 import type { SortDirection } from '../content/elements';
+import type { PortfolioPositionsUpdatedEventDetail } from '../tabs/types';
 import type { AccountSummary, PortfolioSummary } from './api';
+
+export type { PortfolioPositionsUpdatedEventDetail } from '../tabs/types';
 
 type QueryRoot = HTMLElement | Document;
 
@@ -54,7 +57,7 @@ interface PortfolioUpdatePayload extends Partial<PortfolioSummary> {
 
 const PENDING_RETRY_INTERVAL = 500;
 const PENDING_MAX_ATTEMPTS = 10;
-const PORTFOLIO_POSITIONS_UPDATED_EVENT = 'pp-reader:portfolio-positions-updated';
+export const PORTFOLIO_POSITIONS_UPDATED_EVENT = 'pp-reader:portfolio-positions-updated';
 
 function ensurePendingMap(): Map<string, PendingPortfolioUpdate> {
   if (!window.__ppReaderPendingPositions) {
@@ -580,12 +583,15 @@ function processPortfolioPositionsUpdate(
     if (securityUuids.length && typeof window !== 'undefined') {
       try {
         window.dispatchEvent(
-          new CustomEvent(PORTFOLIO_POSITIONS_UPDATED_EVENT, {
-            detail: {
-              portfolioUuid,
-              securityUuids,
+          new CustomEvent<PortfolioPositionsUpdatedEventDetail>(
+            PORTFOLIO_POSITIONS_UPDATED_EVENT,
+            {
+              detail: {
+                portfolioUuid,
+                securityUuids,
+              },
             },
-          }),
+          ),
         );
       } catch (dispatchError) {
         console.warn(

--- a/src/tabs/types.ts
+++ b/src/tabs/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared type declarations for PP Reader dashboard tabs.
+ *
+ * These interfaces centralize cross-tab contracts so the migration from the
+ * legacy JavaScript modules can progressively add stronger typing without
+ * duplicating structural definitions in each module.
+ */
+
+import type { HomeAssistant } from "../types/home-assistant";
+
+export interface PanelConfigLike {
+  entry_id?: string | null;
+  config?: {
+    entry_id?: string | null;
+    _panel_custom?: {
+      config?: {
+        entry_id?: string | null;
+      } | null;
+    } | null;
+  } | null;
+  webcomponent_name?: string | null;
+  [key: string]: unknown;
+}
+
+export interface DashboardTabRenderContext {
+  root: HTMLElement;
+  hass: HomeAssistant | null | undefined;
+  panelConfig: PanelConfigLike | null | undefined;
+}
+
+export type DashboardTabRenderResult = string | void | Promise<string | void>;
+
+export type DashboardTabRenderFn = (
+  root: HTMLElement,
+  hass: HomeAssistant | null | undefined,
+  panelConfig: PanelConfigLike | null | undefined,
+) => DashboardTabRenderResult;
+
+export interface DashboardTabDescriptor {
+  key: string;
+  title: string;
+  render: DashboardTabRenderFn;
+  cleanup?: (context: { key: string }) => void | Promise<void>;
+  [key: string]: unknown;
+}
+
+export type SecurityHistoryRangeKey = "1M" | "6M" | "1Y" | "5Y";
+
+export interface SecurityHistoryRangeState {
+  activeRange: SecurityHistoryRangeKey;
+  [key: string]: unknown;
+}
+
+export interface SecuritySnapshotLike {
+  security_uuid: string;
+  name: string;
+  total_holdings: number;
+  purchase_value_eur: number;
+  current_value_eur: number;
+  gain_abs_eur: number;
+  gain_pct: number;
+  last_price_eur: number | null;
+  source?: string;
+  [key: string]: unknown;
+}
+
+export interface PortfolioPositionsUpdatedEventDetail {
+  portfolioUuid: string;
+  securityUuids: string[];
+}


### PR DESCRIPTION
## Summary
- add a shared TypeScript types module for dashboard tabs covering panel config, render descriptors, history ranges, and security snapshots
- update websocket helpers to consume the shared panel config type and export the portfolio positions update event detail
- expose the new tab types through the dashboard barrel and mark the migration checklist item complete

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e10e007298833095cd0cb55b8f9d3b