### PR TITLE
Type overview tab event flow

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -83,7 +83,7 @@
       - Datei: `src/tabs/overview.ts`
       - Abschnitt: Portfolio-Cache, Tabellenaufbau, `renderDashboard`
       - Ziel: Entferne `@ts-nocheck`, versehe Positions-/Depotdaten mit expliziten Interfaces und strukturiere Hilfsfunktionen so, dass das Dashboard-Markup strikt typisiert entsteht.
-   e) [ ] Typisiere Event-Handler und Lazy-Load-Fluss im Overview-Tab
+   e) [x] Typisiere Event-Handler und Lazy-Load-Fluss im Overview-Tab
       - Datei: `src/tabs/overview.ts`
       - Abschnitt: Toggle-/Sortier-Listener, Reload-Hilfen, DOM-Dataset-Konvertierung
       - Ziel: Schaffe typsichere Signaturen für `attachPortfolioToggleHandler`, Sorting/Retry-Helfer und DOM-Zugriffe auf `HTMLElement`/`QueryRoot`.


### PR DESCRIPTION
## Summary
- tighten the overview tab helper types to use explicit query roots and typed sort keys
- ensure portfolio position sorting and toggles rely on guarded dataset values
- expose typed global helpers for gain metadata application

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e114d66a6483309326dbfd26ddd137