### PR TITLE
feat: add typed security detail tab and chart helpers

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -87,7 +87,7 @@
       - Datei: `src/tabs/overview.ts`
       - Abschnitt: Toggle-/Sortier-Listener, Reload-Hilfen, DOM-Dataset-Konvertierung
       - Ziel: Schaffe typsichere Signaturen für `attachPortfolioToggleHandler`, Sorting/Retry-Helfer und DOM-Zugriffe auf `HTMLElement`/`QueryRoot`.
-   f) [ ] Typisiere Security-Detail-Tab inklusive Historienverwaltung
+   f) [x] Typisiere Security-Detail-Tab inklusive Historienverwaltung
       - Dateien: `src/tabs/security_detail.ts`, `src/content/charting.ts` (oder deklarative Typdatei)
       - Abschnitt: Snapshot-Verarbeitung, Range-Handling, Chart-Integration
       - Ziel: Entferne `@ts-nocheck`, führe typsichere States für History-Ranges/-Cache ein und beschreibe Chart-Hilfsfunktionen inkl. Event-Subscription.


### PR DESCRIPTION
## Summary
- replace the security detail tab implementation with strict TypeScript types covering snapshots, history caches, and range handling
- type the shared charting helpers so line chart rendering and updates expose safe options and tooltip payloads
- mark the security detail migration task as complete in the TypeScript TODO checklist

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e11dc8ca70833084b59d478c04066a