### PR TITLE
Add frontend CI workflow

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -115,7 +115,7 @@
       - Ziel: Erkläre, wie Entwickler Source-Maps im Browser verwenden.
 
 7. CI- und Testabsicherung
-   a) [ ] Ergänze CI-Workflow für Node-Build und Typprüfung
+   a) [x] Ergänze CI-Workflow für Node-Build und Typprüfung
       - Datei: `.github/workflows/<name>.yml` (neu oder bestehend erweitern)
       - Abschnitt: Jobs für `npm ci`, `npm run build`, `npm run typecheck`, `npm run lint:ts`
       - Ziel: Sicherstellen, dass TypeScript-Pipeline auf CI ausgeführt wird.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,40 @@
+name: Frontend Build
+
+on:
+  push:
+    branches:
+      - "main"
+      - "dev"
+  pull_request:
+    branches:
+      - "main"
+      - "dev"
+
+permissions: {}
+
+jobs:
+  node-build:
+    name: Node build and checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@0a44ba7841725637dc9641b007daaf27c0829363 # v4.1.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint TypeScript sources
+        run: npm run lint:ts
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build dashboard bundle
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the frontend lint, typecheck, and build steps
- mark the TypeScript migration checklist item for the workflow as complete

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e12d75cd548330b6266ac366b5556b