### PR TITLE
docs: mark build validation task complete

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -129,7 +129,7 @@
       - Ziel: Testet, dass `dashboard.js` & Begleit-Chunks im `www` Verzeichnis vorhanden sind.
 
 8. Validierung & Release-Vorbereitung
-   a) [ ] Führe `npm run build` und `npm run typecheck` lokal aus
+   a) [x] Führe `npm run build` und `npm run typecheck` lokal aus
       - Ziel: Validierung, dass neue Toolchain fehlerfrei arbeitet und Artefakte erzeugt.
    b) [ ] Starte Home Assistant Dev-Server und prüfe Dashboard-Funktionalität
       - Datei/Tool: `./scripts/develop`


### PR DESCRIPTION
## Summary
- mark the frontend TypeScript migration checklist item for local build and typecheck as complete after validating both commands

## Testing
- npm run build
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1395adb7c83309b4b5a354346734c