### PR TITLE
Document TypeScript dashboard migration

### DIFF
--- a/.docs/TODO_frontend_ts_migration.md
+++ b/.docs/TODO_frontend_ts_migration.md
@@ -134,7 +134,7 @@
    b) [x] Starte Home Assistant Dev-Server und prüfe Dashboard-Funktionalität
       - Datei/Tool: `./scripts/develop`
       - Ziel: Manuelle Regressionstests (Tabs, WebSocket-Updates, DOM-Interaktionen).
-   c) [ ] Aktualisiere `CHANGELOG.md` mit TypeScript-Migrationshinweis
+   c) [x] Aktualisiere `CHANGELOG.md` mit TypeScript-Migrationshinweis
       - Datei: `CHANGELOG.md`
       - Abschnitt: Unreleased / aktuelles Release
       - Ziel: Dokumentiere Einführung der TypeScript-Buildkette und gleichbleibendes Verhalten.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: SemVer (minor bump for new functionality without breaking changes).
 - Exposed always-on WebSocket commands for security drilldowns, including snapshot aggregation and history queries consumed by new frontend API wrappers.【F:custom_components/pp_reader/data/websocket.py†L574-L755】【F:custom_components/pp_reader/data/db_access.py†L291-L384】【F:custom_components/pp_reader/www/pp_reader_dashboard/js/data/api.js†L69-L135】
 
 ### Changed
+- Migrated the dashboard frontend to a TypeScript build pipeline powered by Vite, emitting hashed bundles and declaration files while keeping the module loader in sync for cache busting without altering Home Assistant imports.【F:vite.config.mjs†L1-L34】【F:tsconfig.json†L1-L39】【F:scripts/update_dashboard_module.mjs†L1-L70】【F:src/dashboard.ts†L1-L105】
 - Removed the deprecated `pp_reader_history` feature flag so historical price access is part of the core experience without configuration toggles.【F:custom_components/pp_reader/feature_flags.py†L1-L67】【F:custom_components/pp_reader/data/websocket.py†L537-L755】
 
 ## [0.11.0] - 2025-09-27


### PR DESCRIPTION
## Summary
- add an unreleased changelog entry that highlights the new TypeScript and Vite dashboard toolchain
- check off the corresponding migration task in the frontend TODO list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e147e2fc54833083a86fae82eeae2a