### PR TITLE
Fix setup-node action reference

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@0a44ba7841725637dc9641b007daaf27c0829363 # v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary
- update the frontend workflow to use the current commit for actions/setup-node v4.1.0

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16cfbc8e8833082c2a0225aa0d55d