### PR TITLE
Fix pp-reader panel property upgrade

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
@@ -186,6 +186,11 @@ class PPReaderPanel extends HTMLElement {
     this._loadCss('css/nav.css');
     this.shadowRoot.appendChild(container);
 
+    this._upgradeProperty('hass');
+    this._upgradeProperty('panel');
+    this._upgradeProperty('route');
+    this._upgradeProperty('narrow');
+
     // NEU: Referenz auf das Dashboard-Element sichern
     this._dashboardEl = container.querySelector('pp-reader-dashboard');
     if (!this._dashboardEl) {
@@ -309,6 +314,15 @@ class PPReaderPanel extends HTMLElement {
     if (window.__ppReaderDashboardElements instanceof Set && this._dashboardEl) {
       window.__ppReaderDashboardElements.delete(this._dashboardEl);
     }
+  }
+
+  _upgradeProperty(propertyName) {
+    if (!Object.prototype.hasOwnProperty.call(this, propertyName)) {
+      return;
+    }
+    const value = this[propertyName];
+    delete this[propertyName];
+    this[propertyName] = value;
   }
 }
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -33,6 +33,11 @@ class PPReaderPanel extends HTMLElement {
     this._loadCss('css/nav.css');
     this.shadowRoot.appendChild(container);
 
+    this._upgradeProperty('hass');
+    this._upgradeProperty('panel');
+    this._upgradeProperty('route');
+    this._upgradeProperty('narrow');
+
     // NEU: Referenz auf das Dashboard-Element sichern
     this._dashboardEl = container.querySelector('pp-reader-dashboard');
     if (!this._dashboardEl) {
@@ -156,6 +161,15 @@ class PPReaderPanel extends HTMLElement {
     if (window.__ppReaderDashboardElements instanceof Set && this._dashboardEl) {
       window.__ppReaderDashboardElements.delete(this._dashboardEl);
     }
+  }
+
+  _upgradeProperty(propertyName) {
+    if (!Object.prototype.hasOwnProperty.call(this, propertyName)) {
+      return;
+    }
+    const value = this[propertyName];
+    delete this[propertyName];
+    this[propertyName] = value;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the panel upgrades pre-set Home Assistant properties so hass/panel bindings reach the dashboard component
- add a reusable property-upgrade helper to both the TypeScript source and the shipped panel script

## Testing
- manual: opened http://127.0.0.1:8123/ppreader after login and confirmed the dashboard renders data

------
https://chatgpt.com/codex/tasks/task_e_68e183ce2d60833099e4181fe1452325