### PR TITLE
Enrich security snapshot with purchase aggregates

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -1,5 +1,5 @@
 1. Backend: Snapshot enrichment for purchase and close data
-   a) [ ] Extend `get_security_snapshot` to join purchase aggregates and last close values
+   a) [x] Extend `get_security_snapshot` to join purchase aggregates and last close values
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt: Funktion `get_security_snapshot`
       - Ziel: Liefert zusätzliche Felder `purchase_value_eur`, `average_purchase_price_native`, `last_close_native` (inkl. EUR-Konvertierung bei Bedarf)


### PR DESCRIPTION
## Summary
- extend `get_security_snapshot` to aggregate purchase totals and purchase-weighted averages
- expose purchase value, average price, and last close metadata in the snapshot payload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1c450c15c833095a1bb687e1416f1