### PR TITLE
Update security snapshot typings with purchase metrics

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -17,7 +17,7 @@
       - Ziel: Prüft Null-Bestände, fehlende Käufe und fehlenden Schlusskurs
 
 2. Frontend: Typ- und Snapshot-Verarbeitung erweitern
-   a) [ ] Ergänze Snapshot-Typdefinitionen um neue Felder
+   a) [x] Ergänze Snapshot-Typdefinitionen um neue Felder
       - Datei: `src/tabs/types.ts`
       - Abschnitt: Typen `SecuritySnapshotLike`, verwandte Interfaces
       - Ziel: Typisierte Felder für Kaufwerte, Durchschnittskurs und Schlusskurs bereitstellen

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -65,9 +65,14 @@ export interface SecuritySnapshotResponse {
     name?: string;
     currency_code?: string;
     total_holdings?: number;
+    purchase_value_eur?: number;
+    current_value_eur?: number;
     last_price_native?: number | null;
     last_price_eur?: number;
     market_value_eur?: number;
+    average_purchase_price_native?: number | null;
+    last_close_native?: number | null;
+    last_close_eur?: number | null;
     [key: string]: unknown;
   };
   [key: string]: unknown;

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -58,6 +58,9 @@ type SecuritySnapshotDetail = Partial<Omit<SecuritySnapshotLike, 'security_uuid'
   market_value_eur?: number | string | null;
   current_value_eur?: number | string | null;
   currency_code?: string | null;
+  average_purchase_price_native?: number | string | null;
+  last_close_native?: number | string | null;
+  last_close_eur?: number | string | null;
   last_price?: {
     native?: number | string | null;
     [key: string]: unknown;

--- a/src/tabs/types.ts
+++ b/src/tabs/types.ts
@@ -54,12 +54,17 @@ export interface SecurityHistoryRangeState {
 export interface SecuritySnapshotLike {
   security_uuid: string;
   name: string;
+  currency_code?: string | null;
   total_holdings: number;
   purchase_value_eur: number;
   current_value_eur: number;
   gain_abs_eur: number;
   gain_pct: number;
+  last_price_native?: number | null;
   last_price_eur: number | null;
+  last_close_native?: number | null;
+  last_close_eur?: number | null;
+  average_purchase_price_native?: number | null;
   source?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- extend the security snapshot typing to cover purchase metrics, average purchase price, and last close information
- mirror the new fields on the security detail snapshot helper type for downstream processing
- expose the websocket snapshot response typing updates and mark the roadmap checklist entry complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e214b9fce08330889928a503610e52