### PR TITLE
Add ALL history range option

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -31,7 +31,7 @@
       - Ziel: Wiederverwendbare Berechnungsschritte mit Guarding gegen Null-Bestände
 
 3. Frontend: Range-Handling und Header-Rendering anpassen
-   a) [ ] Range-Selector um Option `ALL` erweitern
+   a) [x] Range-Selector um Option `ALL` erweitern
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt: Konstante `AVAILABLE_HISTORY_RANGES`, Funktion `resolveRangeOptions`, Button-Rendering
       - Ziel: Ermöglicht volle Historie ohne `start_date`-Filter

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -40,12 +40,14 @@ const AVAILABLE_HISTORY_RANGES: readonly SecurityHistoryRangeKey[] = [
   '6M',
   '1Y',
   '5Y',
+  'ALL',
 ];
 const RANGE_DAY_COUNTS: Record<SecurityHistoryRangeKey, number> = {
   '1M': 30,
   '6M': 182,
   '1Y': 365,
   '5Y': 1826,
+  'ALL': Number.POSITIVE_INFINITY,
 };
 
 type SecuritySnapshotDetail = Partial<Omit<SecuritySnapshotLike, 'security_uuid'>> & {

--- a/src/tabs/types.ts
+++ b/src/tabs/types.ts
@@ -44,7 +44,7 @@ export interface DashboardTabDescriptor {
   [key: string]: unknown;
 }
 
-export type SecurityHistoryRangeKey = "1M" | "6M" | "1Y" | "5Y";
+export type SecurityHistoryRangeKey = "1M" | "6M" | "1Y" | "5Y" | "ALL";
 
 export interface SecurityHistoryRangeState {
   activeRange: SecurityHistoryRangeKey;


### PR DESCRIPTION
## Summary
- extend the security detail history ranges with the ALL option and map it to an unbounded day count
- widen the history range key type to include ALL
- keep the implementation checklist in sync with the completed range selector task

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21ff56b048330929d27ce52e7a30c