### PR TITLE
Ensure security detail header uses cached snapshot metrics

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -35,7 +35,7 @@
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt: Konstante `AVAILABLE_HISTORY_RANGES`, Funktion `resolveRangeOptions`, Button-Rendering
       - Ziel: Ermöglicht volle Historie ohne `start_date`-Filter
-   b) [ ] Sicherstellen, dass Headerwerte range-unabhängig bleiben
+   b) [x] Sicherstellen, dass Headerwerte range-unabhängig bleiben
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt: `updateInfoBarContent` und State-Management
       - Ziel: Info-Bar reagiert auf Range; Header nutzt statische Snapshot-Metriken


### PR DESCRIPTION
## Summary
- add a registry accessor so cached snapshot metrics can be reused across range updates
- render the security header metadata with snapshot-derived holdings to keep values independent from range changes
- pass snapshot metrics into the range setup so gain calculations rely on static holdings on subsequent updates

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e221e581408330952e6bcf8eca529f