### PR TITLE
Refine security detail header metrics layout

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -39,7 +39,7 @@
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt: `updateInfoBarContent` und State-Management
       - Ziel: Info-Bar reagiert auf Range; Header nutzt statische Snapshot-Metriken
-   c) [ ] Header-Metadatenlayout auf neue Struktur umstellen
+   c) [x] Header-Metadatenlayout auf neue Struktur umstellen
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt: Funktion `buildHeaderMeta`
       - Ziel: Zeigt Letzten Preis, Tagesänderung, Gesamtänderung, Bestand, Marktwert mit passenden Styles


### PR DESCRIPTION
## Summary
- restructure the security detail header metadata grid to surface price, gain, holdings, and market value with reusable formatting helpers
- mark the header layout checklist item as complete in the feature TODO tracker

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2259ca0188330821d2a5e1fd57520