### PR TITLE
Add baseline support to line chart renderer

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -45,7 +45,7 @@
       - Ziel: Zeigt Letzten Preis, Tagesänderung, Gesamtänderung, Bestand, Marktwert mit passenden Styles
 
 4. Frontend: Chart-Baseline hinzufügen
-   a) [ ] `renderLineChart` um `baseline`-Option erweitern
+   a) [x] `renderLineChart` um `baseline`-Option erweitern
       - Datei: `src/content/charting.ts`
       - Abschnitt: Funktionen `renderLineChart`, `updateLineChart`
       - Ziel: Zeichnet horizontale Linie auf Durchschnittskursniveau und entfernt sie bei fehlenden Daten


### PR DESCRIPTION
## Summary
- extend the charting helpers with a configurable baseline option and internal state
- render and update a horizontal reference line that hides automatically when no value is provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2296ca8b48330aa5e5af6f5ce9c8d