### PR TITLE
Propagate baseline to security detail chart rendering

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -49,7 +49,7 @@
       - Datei: `src/content/charting.ts`
       - Abschnitt: Funktionen `renderLineChart`, `updateLineChart`
       - Ziel: Zeichnet horizontale Linie auf Durchschnittskursniveau und entfernt sie bei fehlenden Daten
-   b) [ ] Chart-Aufruf im Security-Detail mit Baseline versorgen
+   b) [x] Chart-Aufruf im Security-Detail mit Baseline versorgen
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt: Chart-Initialisierung und -Update
       - Ziel: Übermittelt berechnete Durchschnittskurslinie an Chart-Funktionen

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -934,12 +934,16 @@ function normaliseHistoryError(error: unknown): string | null {
 function getHistoryChartOptions(
   host: HTMLElement,
   series: readonly NormalizedHistoryEntry[],
-  { currency }: { currency?: string | null | undefined } = {},
+  {
+    currency,
+    baseline,
+  }: { currency?: string | null | undefined; baseline?: number | null | undefined } = {},
 ): LineChartOptions {
   const measuredWidth = host.clientWidth || host.offsetWidth || 0;
   const width = measuredWidth > 0 ? measuredWidth : 640;
   const height = Math.min(Math.max(Math.floor(width * 0.55), 220), 420);
   const safeCurrency = (currency || '').toUpperCase() || 'EUR';
+  const baselineValue = isFiniteNumber(baseline) ? baseline : null;
 
   return {
     width,
@@ -951,6 +955,12 @@ function getHistoryChartOptions(
       <div class="chart-tooltip-date">${xFormatted}</div>
       <div class="chart-tooltip-value">${yFormatted}&nbsp;${safeCurrency}</div>
     `,
+    baseline:
+      baselineValue != null
+        ? {
+            value: baselineValue,
+          }
+        : null,
   };
 }
 
@@ -962,7 +972,10 @@ const HISTORY_CHART_INSTANCES = new WeakMap<
 function renderHistoryChart(
   host: HTMLElement,
   series: readonly NormalizedHistoryEntry[],
-  options: { currency?: string | null | undefined } = {},
+  options: {
+    currency?: string | null | undefined;
+    baseline?: number | null | undefined;
+  } = {},
 ): void {
   if (!host || !Array.isArray(series) || series.length === 0) {
     return;
@@ -1027,7 +1040,10 @@ function updateHistoryPlaceholder(
   rangeKey: SecurityHistoryRangeKey,
   state: HistoryPlaceholderState,
   historySeries: readonly NormalizedHistoryEntry[],
-  options: { currency?: string | null | undefined } = {},
+  options: {
+    currency?: string | null | undefined;
+    baseline?: number | null | undefined;
+  } = {},
 ): void {
   const placeholderContainer = root.querySelector('.security-detail-placeholder');
   if (!placeholderContainer) {
@@ -1105,7 +1121,10 @@ function scheduleRangeSetup(options: ScheduleRangeSetupOptions): void {
         initialRange,
         initialHistoryState,
         initialHistory,
-        { currency: snapshot?.currency_code },
+        {
+          currency: snapshot?.currency_code,
+          baseline: snapshotMetrics?.averagePurchaseNative ?? null,
+        },
       );
     }
 
@@ -1173,7 +1192,10 @@ function scheduleRangeSetup(options: ScheduleRangeSetupOptions): void {
         rangeKey,
         historyState,
         historySeries,
-        { currency: snapshot?.currency_code },
+        {
+          currency: snapshot?.currency_code,
+          baseline: snapshotMetrics?.averagePurchaseNative ?? null,
+        },
       );
     };
 


### PR DESCRIPTION
## Summary
- pass the precomputed average purchase baseline into security detail chart render/update calls
- reuse cached snapshot metrics when range data loads to keep the baseline constant across updates
- check off the security detail baseline task in the implementation checklist

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e22b68a1c48330bacf17adefcc9413