### PR TITLE
Style chart baseline for security detail

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -59,7 +59,7 @@
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css`
       - Abschnitt: Selektoren für Security-Header-Karten
       - Ziel: Gruppenlayout, Responsive-Anpassungen und Gain-Farben implementieren
-   b) [ ] Styling für Chart-Baseline ergänzen
+   b) [x] Styling für Chart-Baseline ergänzen
       - Datei: `custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css`
       - Abschnitt: Neuer Selektor für Baseline/Dash-Linie (ggf. globaler Chart-Abschnitt)
       - Ziel: Dezente Darstellung der Durchschnittskurs-Linie sicherstellen

--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -608,6 +608,8 @@ tbody tr:hover {
   width: 100%;
   min-height: 220px;
   display: block;
+  --pp-reader-chart-baseline: rgba(96, 125, 139, 0.6);
+  --pp-reader-chart-baseline-dash: 6 4;
 }
 
 .history-chart .line-chart-container {
@@ -672,6 +674,18 @@ tbody tr:hover {
 .line-chart-focus-circle {
   stroke: var(--pp-reader-chart-line, #3f51b5);
   fill: var(--card-background-color);
+}
+
+.line-chart-baseline {
+  stroke: var(
+    --pp-reader-chart-baseline,
+    rgba(96, 125, 139, 0.75)
+  );
+  stroke-width: 1.25px;
+  stroke-dasharray: var(--pp-reader-chart-baseline-dash, 6 4);
+  opacity: 0;
+  transition: opacity 0.25s ease-in-out;
+  pointer-events: none;
 }
 
 .chart-tooltip {


### PR DESCRIPTION
## Summary
- define baseline color variables on the history chart container
- add styling for the chart baseline line element so it renders with a dashed stroke and smooth visibility transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e230671d248330b25bc1de1a16e982