### PR TITLE
docs: add implementation notes for security detail header refresh

### DIFF
--- a/.docs/TODO_security_detail_header_refresh.md
+++ b/.docs/TODO_security_detail_header_refresh.md
@@ -65,7 +65,7 @@
       - Ziel: Dezente Darstellung der Durchschnittskurs-Linie sicherstellen
 
 6. Dokumentation & Kommunikation
-   a) [ ] Konzeptdokument mit Umsetzungshinweisen aktualisieren
+   a) [x] Konzeptdokument mit Umsetzungshinweisen aktualisieren
       - Datei: `.docs/security_detail_header_refresh.md`
       - Abschnitt: Ergänzung "Implementation" bzw. Hinweis auf Fertigstellung
       - Ziel: Status und Learnings dokumentieren

--- a/.docs/security_detail_header_refresh.md
+++ b/.docs/security_detail_header_refresh.md
@@ -149,7 +149,13 @@ No additional decisions.
 
 ---
 
-## 11. Summary of Decisions
+## 11. Implementation Notes (Completed)
+- Backend snapshot enrichment now returns `purchase_value_eur`, `average_purchase_price_native`, and `last_close_native` with guarded conversions so downstream clients receive ready-to-use aggregates.
+- Frontend snapshot handling caches static metrics per security, ensuring the header presents last price, day change, total change, holdings, and market value independent of range selection.
+- Range selector includes the new `ALL` option, while chart rendering draws an average purchase price baseline that disappears automatically when insufficient purchase data exists.
+- Updated CSS refines the security header grid and baseline styling to highlight positive/negative gains without altering existing theme tokens.
+
+## 12. Summary of Decisions
 - Enrich `get_security_snapshot` with purchase and last-close aggregates to support the new header metrics.
 - Compute day/total change once per snapshot and decouple these values from the history range selector.
 - Extend chart utilities and CSS to visualise the average purchase price baseline alongside the expanded header layout.


### PR DESCRIPTION
## Summary
- add completion notes to the security detail header refresh concept document
- mark the corresponding checklist item as completed

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e231e5f5308330a8a9d3305545db4d