### PR TITLE
Fix panel static path registration

### DIFF
--- a/custom_components/pp_reader/__init__.py
+++ b/custom_components/pp_reader/__init__.py
@@ -307,7 +307,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
     await hass.http.async_register_static_paths(
         [
             StaticPathConfig(
-                path=hass.config.path(str(dashboard_folder)),
+                path=str(dashboard_folder.resolve()),
                 url_path="/pp_reader_dashboard",
                 cache_headers=False,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 
+from typing import Any
+
 import pytest
 from homeassistant.config_entries import ConfigEntries
 from homeassistant.core import HomeAssistant
@@ -43,7 +45,11 @@ async def hass(
     await hass.config_entries.async_initialize()
 
     class _HttpStub:
-        async def async_register_static_paths(self, _paths):
+        def __init__(self) -> None:
+            self.registered_static_paths: list[Any] = []
+
+        async def async_register_static_paths(self, paths):  # noqa: ANN001
+            self.registered_static_paths.extend(paths)
             return None
 
         async def async_register_view(self, _view):  # pragma: no cover - compatibility

--- a/tests/test_panel_registration.py
+++ b/tests/test_panel_registration.py
@@ -6,6 +6,7 @@ refresh is still running during Home Assistant startup.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -88,3 +89,10 @@ async def test_placeholder_panel_registered_during_setup(
     placeholder_config = captured_configs[0]
     assert placeholder_config.get("entry_id") is None
     assert placeholder_config.get("placeholder") is True
+
+    assert hass.http.registered_static_paths, "Expected dashboard static path"
+    static_path = hass.http.registered_static_paths[0]
+    expected_folder = (
+        Path(integration.__file__).parent / "www" / "pp_reader_dashboard"
+    )
+    assert Path(static_path.path) == expected_folder.resolve()


### PR DESCRIPTION
## Summary
- register the pp_reader dashboard static files from the integration directory so the panel no longer 404s
- extend the http test stub and panel registration test to assert the correct static path is exposed

## Testing
- pytest tests/test_panel_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a1e0b7a083309ff2f042f2a72046