### PR TITLE
Fix total gain summary on security detail tab

### DIFF
--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -598,13 +598,14 @@ function ensureSnapshotMetrics(
 
   const totalChangeFallbackDiff = computeDelta(currentValueEur, purchaseValueEur);
   const totalChangeEur =
-    totalChangeEurDirect ??
-    (totalChangeFallbackDiff != null ? roundCurrency(totalChangeFallbackDiff) : null);
+    totalChangeFallbackDiff != null
+      ? roundCurrency(totalChangeFallbackDiff)
+      : totalChangeEurDirect;
 
   const totalChangePct =
+    computePercentageChange(currentValueEur, purchaseValueEur) ??
     computePercentageChange(lastPriceNative, averagePurchaseNative) ??
-    computePercentageChange(lastPriceEur, averagePurchaseEur) ??
-    computePercentageChange(currentValueEur, purchaseValueEur);
+    computePercentageChange(lastPriceEur, averagePurchaseEur);
 
   const metrics: SecuritySnapshotMetrics = {
     holdings: safeHoldings,


### PR DESCRIPTION
## Summary
- prefer aggregated purchase/current values when deriving total gain metrics on the security detail tab
- fall back to price-based deltas only when portfolio totals are unavailable and keep percentage change ordering aligned

## Testing
- npm run lint:ts *(fails: missing @eslint/js package in the environment)*
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68e2b202da3c8330ae56f15096a4ad5c