### PR TITLE
Append version query to panel CSS assets

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/panel.js
@@ -178,7 +178,9 @@ async function loadDashboardModule() {
 
 await loadDashboardModule();
 
-const ASSET_BASE_URL = new URL('./', import.meta.url);
+const PANEL_URL = new URL(import.meta.url);
+const ASSET_BASE_URL = new URL('./', PANEL_URL);
+const ASSET_VERSION = PANEL_URL.searchParams.get('v');
 
 class PPReaderPanel extends HTMLElement {
   constructor() {
@@ -255,7 +257,11 @@ class PPReaderPanel extends HTMLElement {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     try {
-      link.href = new URL(relativePath, ASSET_BASE_URL).href;
+      const url = new URL(relativePath, ASSET_BASE_URL);
+      if (ASSET_VERSION) {
+        url.searchParams.set('v', ASSET_VERSION);
+      }
+      link.href = url.href;
     } catch (error) {
       console.error('[pp_reader] Fehler beim Auflösen des CSS-Pfades', relativePath, error);
       return;

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -6,7 +6,9 @@
  */
 import './dashboard';
 
-const ASSET_BASE_URL = new URL('./', import.meta.url);
+const PANEL_URL = new URL(import.meta.url);
+const ASSET_BASE_URL = new URL('./', PANEL_URL);
+const ASSET_VERSION = PANEL_URL.searchParams.get('v');
 
 class PPReaderPanel extends HTMLElement {
   constructor() {
@@ -83,7 +85,11 @@ class PPReaderPanel extends HTMLElement {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     try {
-      link.href = new URL(relativePath, ASSET_BASE_URL).href;
+      const url = new URL(relativePath, ASSET_BASE_URL);
+      if (ASSET_VERSION) {
+        url.searchParams.set('v', ASSET_VERSION);
+      }
+      link.href = url.href;
     } catch (error) {
       console.error('[pp_reader] Fehler beim Auflösen des CSS-Pfades', relativePath, error);
       return;


### PR DESCRIPTION
## Summary
- propagate the panel module's cache-busting version to stylesheet URLs so updated CSS is always fetched

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e39632956c8330b8c94986d67992ab