### PR TITLE
Fix security detail price change info bar layout

### DIFF
--- a/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
+++ b/custom_components/pp_reader/www/pp_reader_dashboard/css/cards.css
@@ -481,6 +481,7 @@ tbody tr:hover {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  align-items: flex-start;
 }
 
 .security-info-item .label {
@@ -490,14 +491,37 @@ tbody tr:hover {
   color: var(--secondary-text-color);
 }
 
+.security-info-item .value-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
 .security-info-item .value {
-  font-size: 1.45rem;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 1.1rem;
   font-weight: 600;
   color: var(--primary-text-color);
 }
 
+.security-info-item .value.positive {
+  color: var(--success-color);
+}
+
+.security-info-item .value.negative {
+  color: var(--error-color);
+}
+
 .security-info-item .value.neutral {
   color: var(--secondary-text-color);
+}
+
+.security-info-item .value.value--percentage {
+  font-size: 0.95rem;
+  font-weight: 500;
 }
 
 .security-range-selector {

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -700,8 +700,10 @@ function buildInfoBar(
     <div class="security-info-bar" data-range="${rangeLabel}">
       <div class="security-info-item">
         <span class="label">Preisänderung (${rangeLabel || 'Zeitraum'})</span>
-        ${formatPriceChangeValue(priceChange, currency)}
-        ${formatPercentageChangeValue(priceChangePct)}
+        <div class="value-row">
+          ${formatPriceChangeValue(priceChange, currency)}
+          ${formatPercentageChangeValue(priceChangePct)}
+        </div>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary
- render the price change values in a dedicated row so they stay together
- update the security info bar styles to compact the text and reuse gain/loss colors

## Testing
- npm run lint:ts *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e3bfcd1b988330a4ddfd73311731dd