### PR TITLE
Add native average price column to portfolio securities schema

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -1,5 +1,5 @@
 1. Schema & Models
-   a) [ ] Add native average column to portfolio securities schema
+   a) [x] Add native average column to portfolio securities schema
       - Datei: `custom_components/pp_reader/data/db_schema.py`
       - Abschnitt/Funktion: `PORTFOLIO_SECURITIES_SCHEMA`
       - Ziel: Ergänzt `avg_price_native` REAL (nullable) pro Position und hält Indizes konsistent.

--- a/custom_components/pp_reader/data/db_schema.py
+++ b/custom_components/pp_reader/data/db_schema.py
@@ -104,6 +104,7 @@ PORTFOLIO_SECURITIES_SCHEMA = [
                 ELSE NULL
             END
         ) STORED,                          -- Durchschnittlicher Kaufpreis in Cent
+        avg_price_native REAL,             -- Durchschnittlicher Kaufpreis in nativer Währungseinheit
         current_value REAL DEFAULT 0.0,    -- Aktueller Wert des Bestands in Cent
         PRIMARY KEY (portfolio_uuid, security_uuid),
         FOREIGN KEY (portfolio_uuid) REFERENCES portfolios(uuid),


### PR DESCRIPTION
## Summary
- add an avg_price_native column to the portfolio_securities schema to store native average purchase prices
- mark the corresponding native average purchase price checklist item as completed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3dd0bc160833093ab871c03368a82