### PR TITLE
Add runtime migration for avg_price_native column

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -3,7 +3,7 @@
       - Datei: `custom_components/pp_reader/data/db_schema.py`
       - Abschnitt/Funktion: `PORTFOLIO_SECURITIES_SCHEMA`
       - Ziel: Ergänzt `avg_price_native` REAL (nullable) pro Position und hält Indizes konsistent.
-   b) [ ] Implement runtime migration for avg_price_native
+   b) [x] Implement runtime migration for avg_price_native
       - Datei: `custom_components/pp_reader/data/db_init.py`
       - Abschnitt/Funktion: Schema-Migrationsroutine (`_ensure_schema` / `ensure_portfolio_tables`)
       - Ziel: Fügt `avg_price_native` via `ALTER TABLE` hinzu und verhindert doppelte Ausführung.


### PR DESCRIPTION
## Summary
- add a runtime migration that adds the avg_price_native column to portfolio_securities when missing
- invoke the migration during database initialization alongside the existing runtime migrations
- update the native average purchase price checklist to reflect the completed migration task

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3df2792fc83309bdc883677c09b1e