### PR TITLE
Extend portfolio security model with native avg price

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -7,7 +7,7 @@
       - Datei: `custom_components/pp_reader/data/db_init.py`
       - Abschnitt/Funktion: Schema-Migrationsroutine (`_ensure_schema` / `ensure_portfolio_tables`)
       - Ziel: Fügt `avg_price_native` via `ALTER TABLE` hinzu und verhindert doppelte Ausführung.
-   c) [ ] Erweitere PortfolioSecurity-Datenmodell um native Durchschnittspreise
+   c) [x] Erweitere PortfolioSecurity-Datenmodell um native Durchschnittspreise
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: `PortfolioSecurity` Dataclass & Loader (`get_security_snapshot`, `iter_portfolio_securities`)
       - Ziel: Liest neue Spalte, initialisiert mit `None` und stellt Rückwärtskompatibilität sicher.

--- a/custom_components/pp_reader/data/db_access.py
+++ b/custom_components/pp_reader/data/db_access.py
@@ -95,6 +95,7 @@ class PortfolioSecurity:
     current_holdings: float  # Aktueller Bestand des Wertpapiers im Depot
     purchase_value: int  # Gesamter Kaufpreis des Bestands in Cent
     avg_price: float | None = None  # Durchschnittlicher Kaufpreis in Cent
+    avg_price_native: float | None = None  # Durchschnittlicher Kaufpreis in nativer Währung
     current_value: float | None = None  # Aktueller Wert des Bestands in Cent
 
 
@@ -365,7 +366,7 @@ def get_portfolio_securities(
         cur = conn.execute(
             """
             SELECT portfolio_uuid, security_uuid, current_holdings,
-                   purchase_value, avg_price, current_value
+                   purchase_value, avg_price, avg_price_native, current_value
             FROM portfolio_securities
             WHERE portfolio_uuid = ?
         """,
@@ -387,7 +388,7 @@ def get_all_portfolio_securities(db_path: Path) -> list[PortfolioSecurity]:
     try:
         cur = conn.execute("""
             SELECT portfolio_uuid, security_uuid, current_holdings,
-                   purchase_value, avg_price, current_value
+                   purchase_value, avg_price, avg_price_native, current_value
             FROM portfolio_securities
         """)
         return [PortfolioSecurity(*row) for row in cur.fetchall()]


### PR DESCRIPTION
## Summary
- add avg_price_native to the PortfolioSecurity dataclass
- load avg_price_native from portfolio_securities queries so rows include the new column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e222b968833084fe6a777f0a82bd