### PR TITLE
Add tests for native average purchase price data model

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -11,7 +11,7 @@
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: `PortfolioSecurity` Dataclass & Loader (`get_security_snapshot`, `iter_portfolio_securities`)
       - Ziel: Liest neue Spalte, initialisiert mit `None` und stellt Rückwärtskompatibilität sicher.
-   d) [ ] Aktualisiere zugehörige Tests/Fixtures für erweitertes Datenmodell
+   d) [x] Aktualisiere zugehörige Tests/Fixtures für erweitertes Datenmodell
       - Datei: `tests/` (relevante Module für `db_access`)
       - Abschnitt/Funktion: Snapshot-/Dataclass-Tests
       - Ziel: Deckung für neue Spalte herstellen und Nullwerte berücksichtigen.


### PR DESCRIPTION
## Summary
- extend the db access test fixture to seed the new avg_price_native column
- add coverage ensuring portfolio security loaders expose avg_price_native values
- mark the native average purchase price test checklist item as complete

## Testing
- pytest tests/test_db_access.py

------
https://chatgpt.com/codex/tasks/task_e_68e3e4fac43c8330a9947838749fbc41