### PR TITLE
Add native purchase metrics to FIFO helper

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -17,7 +17,7 @@
       - Ziel: Deckung für neue Spalte herstellen und Nullwerte berücksichtigen.
 
 2. Calculation Pipeline
-   a) [ ] Erweitere FIFO-Hilfsfunktion zur Berechnung nativer Durchschnittspreise
+   a) [x] Erweitere FIFO-Hilfsfunktion zur Berechnung nativer Durchschnittspreise
       - Datei: `custom_components/pp_reader/logic/securities.py`
       - Abschnitt/Funktion: `db_calculate_sec_purchase_value` (oder neue Helper-Funktion)
       - Ziel: Liefert sowohl EUR-Gesamten als auch gewichteten nativen Durchschnitt pro Security.

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -990,13 +990,14 @@ class _SyncRunner:
             "sync_from_pclient: Berechne und synchronisiere portfolio_securities..."
         )
         current_holdings = db_calculate_current_holdings(self.all_transactions)
-        purchase_values = db_calculate_sec_purchase_value(
+        purchase_metrics = db_calculate_sec_purchase_value(
             self.all_transactions, self.db_path
         )
 
         current_hold_pur: dict[tuple[str, str], dict[str, Any]] = {}
         for key, holdings in current_holdings.items():
-            purchase_value = purchase_values.get(key, 0.0)
+            metrics = purchase_metrics.get(key)
+            purchase_value = metrics.purchase_value if metrics else 0.0
             # Falls der Kaufwert wegen fehlender FX-Daten noch nicht
             # berechnet werden konnte, behalten wir die Position dennoch
             # für die Bewertung bei (purchase_value fällt dann auf 0.0).

--- a/custom_components/pp_reader/prices/price_service.py
+++ b/custom_components/pp_reader/prices/price_service.py
@@ -426,7 +426,7 @@ def _refresh_impacted_portfolio_securities(
             current_holdings = (
                 db_calculate_current_holdings(transactions) if transactions else {}
             )
-            purchase_values = (
+            purchase_metrics = (
                 db_calculate_sec_purchase_value(transactions, db_path)
                 if transactions
                 else {}
@@ -435,7 +435,8 @@ def _refresh_impacted_portfolio_securities(
             current_hold_pur: dict[tuple[str, str], dict[str, float]] = {}
             for key in impacted_pairs:
                 holdings = current_holdings.get(key)
-                purchase_value = purchase_values.get(key)
+                metrics = purchase_metrics.get(key)
+                purchase_value = metrics.purchase_value if metrics else None
 
                 if holdings is None and key in existing_entries:
                     holdings = existing_entries[key][0]


### PR DESCRIPTION
## Summary
- extend the FIFO purchase calculator to expose native weighted averages alongside EUR totals
- return structured purchase metrics to callers and keep sync/price refresh logic compatible
- update the native average TODO checklist for the calculation helper step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e8a14c148330865babc53c03c5d1