### PR TITLE
Ensure transaction unit metadata reaches purchase calculations

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -25,7 +25,7 @@
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: `_sync_portfolio_securities`
       - Ziel: Persistiert `avg_price_native` zusammen mit bestehenden Feldern; setzt auf NULL bei null Beständen.
-   c) [ ] Stelle Zugriff auf `transaction_units` FX-Metadaten sicher
+   c) [x] Stelle Zugriff auf `transaction_units` FX-Metadaten sicher
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: Transaktionsvorbereitung innerhalb `_sync_portfolio_securities`
       - Ziel: Verknüpft native Beträge/FX-Daten mit FIFO-Berechnung ohne zusätzliche RPCs.

--- a/custom_components/pp_reader/data/sync_from_pclient.py
+++ b/custom_components/pp_reader/data/sync_from_pclient.py
@@ -991,7 +991,9 @@ class _SyncRunner:
         )
         current_holdings = db_calculate_current_holdings(self.all_transactions)
         purchase_metrics = db_calculate_sec_purchase_value(
-            self.all_transactions, self.db_path
+            self.all_transactions,
+            self.db_path,
+            tx_units=self.tx_units,
         )
 
         current_hold_pur: dict[tuple[str, str], dict[str, Any]] = {}


### PR DESCRIPTION
## Summary
- pass cached transaction unit FX metadata into the portfolio security purchase calculator during sync
- mark the TODO checklist item for wiring transaction unit data as complete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ec7057348330bed8199925493150