### PR TITLE
Persist native average price in portfolio sync

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -21,7 +21,7 @@
       - Datei: `custom_components/pp_reader/logic/securities.py`
       - Abschnitt/Funktion: `db_calculate_sec_purchase_value` (oder neue Helper-Funktion)
       - Ziel: Liefert sowohl EUR-Gesamten als auch gewichteten nativen Durchschnitt pro Security.
-   b) [ ] Nutze native Kaufpreise während Portfolio-Sync
+   b) [x] Nutze native Kaufpreise während Portfolio-Sync
       - Datei: `custom_components/pp_reader/data/sync_from_pclient.py`
       - Abschnitt/Funktion: `_sync_portfolio_securities`
       - Ziel: Persistiert `avg_price_native` zusammen mit bestehenden Feldern; setzt auf NULL bei null Beständen.


### PR DESCRIPTION
## Summary
- store the computed native average purchase price alongside holdings during portfolio sync
- update the portfolio securities upsert to read and write the new avg_price_native column
- mark the native average purchase price sync item as complete in the implementation checklist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3efb02c7c833080d2de33f146a328