### PR TITLE
Expose native average price in position payloads

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -39,7 +39,7 @@
       - Datei: `custom_components/pp_reader/data/db_access.py`
       - Abschnitt/Funktion: `get_security_snapshot`
       - Ziel: Gibt `avg_price_native` unverändert zurück und entfernt EUR→Native Umrechnungen.
-   b) [ ] Aktualisiere WebSocket/REST Payloads
+   b) [x] Aktualisiere WebSocket/REST Payloads
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Abschnitt/Funktion: Serializer für `portfolio_security`/`security_snapshot`
       - Ziel: Überträgt `avg_price_native`, toleriert NULL, behält bestehende Felder.

--- a/custom_components/pp_reader/data/event_push.py
+++ b/custom_components/pp_reader/data/event_push.py
@@ -119,6 +119,16 @@ def _normalize_position_entry(item: Mapping[str, Any]) -> dict[str, Any] | None:
         except (TypeError, ValueError):
             return 0.0
 
+    avg_native_raw = item.get("average_purchase_price_native")
+    avg_native: float | None
+    if avg_native_raw is None:
+        avg_native = None
+    else:
+        try:
+            avg_native = round(float(avg_native_raw), 6)
+        except (TypeError, ValueError):
+            avg_native = None
+
     normalized: dict[str, Any] = {
         "security_uuid": security_uuid,
         "name": item.get("name"),
@@ -127,6 +137,7 @@ def _normalize_position_entry(item: Mapping[str, Any]) -> dict[str, Any] | None:
         "current_value": _float("current_value"),
         "gain_abs": _float("gain_abs"),
         "gain_pct": _float("gain_pct"),
+        "average_purchase_price_native": avg_native,
     }
 
     return normalized


### PR DESCRIPTION
## Summary
- include the stored native average price when loading portfolio positions
- preserve the new field in websocket and event push payloads for positions
- mark the TODO checklist item for API payload wiring as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f965b6b88330988f26291d0d5029