### PR TITLE
Adjust websocket snapshot test for native avg price

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -43,7 +43,7 @@
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Abschnitt/Funktion: Serializer für `portfolio_security`/`security_snapshot`
       - Ziel: Überträgt `avg_price_native`, toleriert NULL, behält bestehende Felder.
-   c) [ ] Passe API Tests an
+   c) [x] Passe API Tests an
       - Datei: `tests/` (Websocket/API Tests)
       - Abschnitt/Funktion: Snapshot/Endpoint-Assertions
       - Ziel: Erwartet neue Feldwerte und prüft Nullverhalten.

--- a/tests/test_ws_security_history.py
+++ b/tests/test_ws_security_history.py
@@ -272,13 +272,14 @@ def seeded_history_db(tmp_path: Path) -> Path:
                 security_uuid,
                 current_holdings,
                 purchase_value,
-                current_value
+                current_value,
+                avg_price_native
             )
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
             [
-                ("portfolio-1", "sec-1", 1.5, 0, 0),
-                ("portfolio-2", "sec-1", 2.0, 0, 0),
+                ("portfolio-1", "sec-1", 1.5, 0, 0, 12.34),
+                ("portfolio-2", "sec-1", 2.0, 0, 0, 16.78),
             ],
         )
         conn.commit()
@@ -436,7 +437,11 @@ def test_ws_get_security_snapshot_success(seeded_history_db: Path) -> None:
         "last_price_eur": 12.5,
         "market_value_eur": 43.75,
         "purchase_value_eur": 0.0,
-        "average_purchase_price_native": None,
+        "average_purchase_price_native": pytest.approx(
+            14.877143,
+            rel=0,
+            abs=1e-6,
+        ),
         "last_close_native": 0.0001,
         "last_close_eur": 0.0001,
     }


### PR DESCRIPTION
## Summary
- seed websocket test database with native average purchase price values
- update security snapshot websocket assertion to verify averaged native price
- mark the native average API test task as complete in the TODO tracker

## Testing
- `pytest tests/test_ws_security_history.py::test_ws_get_security_snapshot_success`


------
https://chatgpt.com/codex/tasks/task_e_68e3fb8f882c83308512a133fc383208