### PR TITLE
Use native average purchase price in security detail

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -49,7 +49,7 @@
       - Ziel: Erwartet neue Feldwerte und prüft Nullverhalten.
 
 4. Frontend Integration
-   a) [ ] Verwende gelieferten nativen Durchschnittspreis ohne Fallbacks
+   a) [x] Verwende gelieferten nativen Durchschnittspreis ohne Fallbacks
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt/Funktion: `ensureSnapshotMetrics`
       - Ziel: Entfernt FX-Heuristiken, vertraut auf `average_purchase_price_native` und behandelt `null` korrekt.

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -539,7 +539,6 @@ function convertNativeDiffToEur(
 function computeHoldingsAdjustedEurChange(
   holdings: number | null,
   diffNative: number | null,
-  diffEur: number | null,
   fxRate: number | null,
 ): number | null {
   if (!isFiniteNumber(holdings)) {
@@ -547,15 +546,11 @@ function computeHoldingsAdjustedEurChange(
   }
 
   const nativeInEur = convertNativeDiffToEur(diffNative, fxRate);
-  if (nativeInEur != null) {
-    return roundCurrency(nativeInEur * holdings);
+  if (nativeInEur == null) {
+    return null;
   }
 
-  if (isFiniteNumber(diffEur)) {
-    return roundCurrency(diffEur * holdings);
-  }
-
-  return null;
+  return roundCurrency(nativeInEur * holdings);
 }
 
 function computeAveragePurchaseEur(
@@ -631,7 +626,6 @@ function ensureSnapshotMetrics(
   const totalChangeEurDirect = computeHoldingsAdjustedEurChange(
     safeHoldings,
     computeDelta(lastPriceNative, averagePurchaseNative),
-    computeDelta(lastPriceEur, averagePurchaseEur),
     safeFxRate,
   );
 


### PR DESCRIPTION
## Summary
- remove the EUR fallback when deriving holdings-based EUR deltas so the UI trusts the native average purchase price
- update the native average TODO checklist entry to reflect the completed frontend wiring

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3ff4761c4833088d89af3e9722af7