### PR TITLE
Add tests for native average purchase price frontend

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -57,7 +57,7 @@
       - Datei: `src/tabs/security_detail.ts`
       - Abschnitt/Funktion: Rendering der Detailmetrik & Chart-Baseline
       - Ziel: Verwendet native Werte für Achsen/Baselines; behält EUR Vergleichswerte.
-   c) [ ] Ergänze Frontend Tests/Typen
+   c) [x] Ergänze Frontend Tests/Typen
       - Datei: `tests/` oder `src/__tests__/` (TS Testdateien) & `src/types/`
       - Abschnitt/Funktion: Snapshot/Chart Tests & Typdefinitionen
       - Ziel: Erwartet `average_purchase_price_native` als optionales Feld und deckt Rendering ab.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.13.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "^20.19.19",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.5.0",
@@ -1176,10 +1178,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3166,6 +3197,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.13.0",
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^20.19.19",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.5.0",

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -70,7 +70,7 @@ export interface SecuritySnapshotResponse {
     last_price_native?: number | null;
     last_price_eur?: number;
     market_value_eur?: number;
-    average_purchase_price_native?: number | null;
+    average_purchase_price_native?: number | string | null;
     last_close_native?: number | null;
     last_close_eur?: number | null;
     [key: string]: unknown;

--- a/src/tabs/__tests__/security_detail.metrics.test.ts
+++ b/src/tabs/__tests__/security_detail.metrics.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for native average purchase price handling on the
+ * security detail tab. Ensures the dashboard consumes backend-provided
+ * values without falling back to heuristic conversions.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { __TEST_ONLY__ } from '../security_detail';
+
+const {
+  ensureSnapshotMetricsForTest,
+  getHistoryChartOptionsForTest,
+  clearSnapshotMetricsRegistryForTest,
+} = __TEST_ONLY__;
+
+test('ensureSnapshotMetricsForTest returns provided native averages verbatim', () => {
+  clearSnapshotMetricsRegistryForTest();
+
+  const metrics = ensureSnapshotMetricsForTest('security-avg', {
+    security_uuid: 'security-avg',
+    total_holdings: '4',
+    purchase_value_eur: '200',
+    current_value_eur: '260',
+    average_purchase_price_native: '123.45',
+    last_price_native: '130.1',
+    last_close_native: '125.3',
+    last_price_eur: '65.5',
+    last_close_eur: '60.5',
+  });
+
+  assert.ok(metrics, 'expected metrics to be materialised');
+  assert.strictEqual(metrics?.averagePurchaseNative, 123.45);
+  assert.strictEqual(metrics?.averagePurchaseEur, 50);
+});
+
+test('ensureSnapshotMetricsForTest keeps native average null when missing', () => {
+  clearSnapshotMetricsRegistryForTest();
+
+  const metrics = ensureSnapshotMetricsForTest('security-null', {
+    security_uuid: 'security-null',
+    total_holdings: 5,
+    purchase_value_eur: 500,
+    last_price_native: 120,
+    last_close_native: 118,
+  });
+
+  assert.ok(metrics, 'metrics should still be generated with partial data');
+  assert.strictEqual(metrics?.averagePurchaseNative, null);
+
+  const cleared = ensureSnapshotMetricsForTest('security-null', null);
+  assert.strictEqual(cleared, null, 'metrics must be cleared when snapshot is removed');
+});
+
+test('getHistoryChartOptionsForTest injects the native baseline into chart options', () => {
+  clearSnapshotMetricsRegistryForTest();
+
+  const dom = new JSDOM('<!doctype html><div id="host"></div>');
+  const host = dom.window.document.getElementById('host');
+  if (!host) {
+    throw new Error('Failed to create chart host element for test');
+  }
+
+  Object.defineProperty(host, 'clientWidth', { value: 720, configurable: true });
+  Object.defineProperty(host, 'offsetWidth', { value: 720, configurable: true });
+
+  const baseline = 98.7654;
+  const series = [
+    {
+      date: new Date('2024-01-02T00:00:00Z'),
+      close: 101.23,
+    },
+  ] as const;
+
+  const options = getHistoryChartOptionsForTest(host, series, { currency: 'usd', baseline });
+
+  assert.ok(options.baseline, 'baseline configuration should be present when provided');
+  assert.strictEqual(options.baseline?.value, baseline);
+  assert.ok(Array.isArray(options.series));
+  assert.strictEqual(options.series?.length, 1);
+
+  const tooltipRenderer = options.tooltipRenderer;
+  assert.ok(tooltipRenderer, 'expected tooltip renderer to be defined');
+
+  const tooltipContent = tooltipRenderer({
+    point: {
+      index: 0,
+      data: series[0],
+      xValue: 0,
+      yValue: series[0].close,
+      x: 0,
+      y: 0,
+    },
+    xFormatted: '2024-01-02',
+    yFormatted: '101.23',
+    data: series[0],
+    index: 0,
+  });
+
+  assert.match(tooltipContent, /USD/);
+});

--- a/src/tabs/security_detail.ts
+++ b/src/tabs/security_detail.ts
@@ -128,6 +128,14 @@ const SNAPSHOT_METRICS_REGISTRY: SnapshotMetricsRegistry = new Map();
 const LIVE_UPDATE_EVENT = 'pp-reader:portfolio-positions-updated';
 const LIVE_UPDATE_HANDLERS = new Map<string, LiveUpdateHandler>();
 
+export const __TEST_ONLY__ = {
+  ensureSnapshotMetricsForTest: ensureSnapshotMetrics,
+  getHistoryChartOptionsForTest: getHistoryChartOptions,
+  clearSnapshotMetricsRegistryForTest: () => {
+    SNAPSHOT_METRICS_REGISTRY.clear();
+  },
+};
+
 function buildCachedSnapshotNotice(params: {
   fallbackUsed: boolean;
   flaggedAsCache: boolean;

--- a/src/tabs/types.ts
+++ b/src/tabs/types.ts
@@ -64,7 +64,7 @@ export interface SecuritySnapshotLike {
   last_price_eur: number | null;
   last_close_native?: number | null;
   last_close_eur?: number | null;
-  average_purchase_price_native?: number | null;
+  average_purchase_price_native?: number | string | null;
   source?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- expose test helpers and extend snapshot types to cover native average purchase price inputs
- add TypeScript tests validating snapshot metrics and chart baseline behaviour for native prices
- install Node typings needed for the new tests and mark the implementation checklist item as complete

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e4081685f08330848bbb187bdf68d0