### PR TITLE
docs: note native average metrics for developers

### DIFF
--- a/.docs/TODO_native_avg_purchase_price.md
+++ b/.docs/TODO_native_avg_purchase_price.md
@@ -71,7 +71,7 @@
       - Datei: `CHANGELOG.md`
       - Abschnitt/Funktion: Unreleased / kommende Version
       - Ziel: Notiert Einführung nativer Durchschnittspreise und Migration.
-   c) [ ] Aktualisiere Entwickler-Doku bei Bedarf
+   c) [x] Aktualisiere Entwickler-Doku bei Bedarf
       - Datei: `README-dev.md` oder `README.md`
       - Abschnitt/Funktion: Setup/Feature Beschreibung
       - Ziel: Weist auf neue Felder und Testabdeckung hin.

--- a/README-dev.md
+++ b/README-dev.md
@@ -34,6 +34,7 @@ Additional setup variations (Windows, devcontainers) are covered in [TESTING.md 
 - The integration bootstraps state under `hass.data[DOMAIN][entry_id]` and relies on `fetch_live_portfolios` to aggregate data for WebSocket commands and events. Schema changes must keep this helper in sync.
 - Live pricing uses `yahooquery` with a minimum polling interval of 300 seconds. Respect the coordinator locks and logging expectations when adjusting the price service or revaluation logic.
 - The SQLite layer persists portfolio mirrors as well as daily close history for securities. Imports run diff-based updates, and automatic backups create snapshots every six hours; manual backups are exposed through `pp_reader.trigger_backup_debug`.
+- `portfolio_securities` stores both EUR-denominated purchase totals (`purchase_value`, `avg_price`) and the native weighted average per share (`avg_price_native`). Keep `_sync_portfolio_securities` and `db_calculate_sec_purchase_value` in sync so the FIFO helper continues to emit both values.
 
 ## Frontend workflow
 The dashboard is authored in TypeScript and built with Vite. Bundles live in `custom_components/pp_reader/www/pp_reader_dashboard/js/` and are referenced by `dashboard.module.js`.
@@ -58,6 +59,7 @@ python -m script.hassfest  # optional
 - Pytest relies on fixtures from `pytest-homeassistant-custom-component`; ensure the virtualenv is active and `requirements-dev.txt` is installed.
 - Frontend smoke tests live under `tests/frontend/` and execute Node scripts (powered by `jsdom`) to validate dashboard bundles.
 - For verbose logging during async tests, invoke `pytest -vv -o log_cli=true --log-cli-level=INFO`.
+- FIFO coverage for the native average purchase price lives in `tests/logic/test_securities_fifo.py`; extend these cases when changing purchase calculations or currency handling.
 
 More background on the available fixtures and test structure is available in [TESTING.md](TESTING.md).
 


### PR DESCRIPTION
## Summary
- add developer guide notes describing the native average purchase price column and pipeline helpers
- reference the FIFO test coverage for native average pricing changes
- mark the native average developer documentation item as complete in the project checklist

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e41ab1a9cc8330bbb3c68f10e30547