### PR TITLE
Fix missing FX rates showing as zero market values

### DIFF
--- a/custom_components/pp_reader/data/db_access.py
+++ b/custom_components/pp_reader/data/db_access.py
@@ -480,7 +480,14 @@ def get_security_snapshot(db_path: Path, security_uuid: str) -> dict[str, Any]:
         last_price_eur = normalize_price_to_eur_sync(
             raw_price, currency_code, reference_date, db_path
         )
-        market_value_eur = round(total_holdings * last_price_eur, 2)
+        last_price_eur_value = (
+            round(last_price_eur, 4) if last_price_eur is not None else None
+        )
+        market_value_eur = (
+            round(total_holdings * last_price_eur, 2)
+            if last_price_eur is not None
+            else None
+        )
         purchase_value_eur = round(purchase_value_cents / 100, 2)
         average_purchase_price_native = None
         if (
@@ -517,7 +524,7 @@ def get_security_snapshot(db_path: Path, security_uuid: str) -> dict[str, Any]:
             "currency_code": currency_code,
             "total_holdings": round(total_holdings, 6),
             "last_price_native": last_price_native,
-            "last_price_eur": round(last_price_eur, 4),
+            "last_price_eur": last_price_eur_value,
             "market_value_eur": market_value_eur,
             "purchase_value_eur": purchase_value_eur,
             "average_purchase_price_native": average_purchase_price_native,

--- a/custom_components/pp_reader/data/websocket.py
+++ b/custom_components/pp_reader/data/websocket.py
@@ -166,7 +166,7 @@ def _serialise_security_snapshot(snapshot: Mapping[str, Any] | None) -> dict[str
             "total_holdings": 0.0,
             "last_price_native": None,
             "last_price_eur": None,
-            "market_value_eur": 0.0,
+            "market_value_eur": None,
             "purchase_value_eur": 0.0,
             "average_purchase_price_native": None,
             "last_close_native": None,
@@ -190,7 +190,9 @@ def _serialise_security_snapshot(snapshot: Mapping[str, Any] | None) -> dict[str
         snapshot.get("last_price_native")
     )
     data["last_price_eur"] = _coerce_optional_float(snapshot.get("last_price_eur"))
-    data["market_value_eur"] = _coerce_float(snapshot.get("market_value_eur"))
+    data["market_value_eur"] = _coerce_optional_float(
+        snapshot.get("market_value_eur")
+    )
     data["purchase_value_eur"] = _coerce_float(snapshot.get("purchase_value_eur"))
     data["average_purchase_price_native"] = _coerce_optional_float(
         snapshot.get("average_purchase_price_native")

--- a/custom_components/pp_reader/logic/portfolio.py
+++ b/custom_components/pp_reader/logic/portfolio.py
@@ -37,10 +37,10 @@ def normalize_shares(raw_shares: int) -> float:
 
 def normalize_price_to_eur_sync(
     raw_price: int | None, currency_code: str, reference_date: datetime, db_path: Path
-) -> float:
+) -> float | None:
     """Normalize a raw security price to EUR using stored FX rates."""
     if not raw_price:
-        return 0.0
+        return None
 
     price = normalize_price(raw_price)
     if currency_code == "EUR":
@@ -51,7 +51,7 @@ def normalize_price_to_eur_sync(
         fx_rates = load_latest_rates_sync(reference_date, db_path)
     except Exception:  # pragma: no cover - defensive
         _LOGGER.exception("Fehler beim Laden der Wechselkurse für %s", currency_code)
-        return 0.0
+        return None
     rate = fx_rates.get(currency_code)
     if rate:
         return price / rate
@@ -61,7 +61,7 @@ def normalize_price_to_eur_sync(
         currency_code,
         reference_date.strftime("%Y-%m-%d"),
     )
-    return 0.0
+    return None
 
 
 def calculate_holdings(transactions: list[Transaction]) -> dict[str, float]:

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -69,7 +69,7 @@ export interface SecuritySnapshotResponse {
     current_value_eur?: number;
     last_price_native?: number | null;
     last_price_eur?: number;
-    market_value_eur?: number;
+    market_value_eur?: number | null;
     average_purchase_price_native?: number | string | null;
     last_close_native?: number | null;
     last_close_eur?: number | null;


### PR DESCRIPTION
## Summary
- treat missing FX conversions as unknown when normalizing snapshot data
- propagate null market values through websocket payloads and update TypeScript types
- avoid rounding missing EUR prices when computing snapshot values

## Testing
- pytest tests/test_db_access.py

------
https://chatgpt.com/codex/tasks/task_e_68e4bb7be6648330846cba3248a64f7c