### PR TITLE
Add live snapshot price to security history chart

### DIFF
--- a/src/tabs/__tests__/security_detail.metrics.test.ts
+++ b/src/tabs/__tests__/security_detail.metrics.test.ts
@@ -14,6 +14,7 @@ const {
   ensureSnapshotMetricsForTest,
   getHistoryChartOptionsForTest,
   clearSnapshotMetricsRegistryForTest,
+  mergeHistoryWithSnapshotPriceForTest,
 } = __TEST_ONLY__;
 
 test('ensureSnapshotMetricsForTest returns provided native averages verbatim', () => {
@@ -102,4 +103,59 @@ test('getHistoryChartOptionsForTest injects the native baseline into chart optio
   });
 
   assert.match(tooltipContent, /USD/);
+});
+
+test('mergeHistoryWithSnapshotPriceForTest appends the latest snapshot price for new days', () => {
+  const baseSeries = [
+    { date: new Date('2024-05-10T00:00:00Z'), close: 21.5 },
+    { date: new Date('2024-05-13T00:00:00Z'), close: 22.75 },
+  ];
+
+  const snapshot = {
+    last_price_native: '24.1',
+    last_price_fetched_at: '2024-05-14T09:15:00Z',
+    currency_code: 'USD',
+  } as const;
+
+  const merged = mergeHistoryWithSnapshotPriceForTest(baseSeries, snapshot);
+
+  assert.strictEqual(baseSeries.length, 2, 'base history must remain unchanged');
+  assert.strictEqual(merged.length, 3, 'merged series should include the live price entry');
+
+  const lastEntry = merged[merged.length - 1];
+  assert.ok(lastEntry, 'expected merged series to provide a trailing entry');
+  assert.strictEqual(lastEntry.close, 24.1);
+
+  const lastEntryDate = new Date(lastEntry.date as Date | string | number);
+  assert.ok(!Number.isNaN(lastEntryDate.getTime()));
+  assert.ok(
+    lastEntryDate.getTime() > new Date(baseSeries[baseSeries.length - 1].date).getTime(),
+    'live price entry should be newer than the historical close',
+  );
+});
+
+test('mergeHistoryWithSnapshotPriceForTest replaces existing closes on the same day', () => {
+  const baseSeries = [
+    { date: new Date('2024-05-13T00:00:00Z'), close: 22.75 },
+    { date: new Date('2024-05-14T00:00:00Z'), close: 23.0 },
+  ];
+
+  const snapshot = {
+    last_price_native: 23.65,
+    last_price_fetched_at: '2024-05-14T15:45:00Z',
+    currency_code: 'USD',
+  } as const;
+
+  const merged = mergeHistoryWithSnapshotPriceForTest(baseSeries, snapshot);
+
+  assert.strictEqual(merged.length, 2, 'series length should remain unchanged when replacing');
+  assert.strictEqual(merged[1].close, 23.65);
+
+  const replacementDate = new Date(merged[1].date as Date | string | number);
+  assert.strictEqual(
+    replacementDate.getUTCFullYear(),
+    2024,
+    'replacement entry should preserve the day component',
+  );
+  assert.strictEqual(replacementDate.getUTCDate(), 14);
 });


### PR DESCRIPTION
## Summary
- add helpers to append the latest snapshot price to the cached history series used by the security detail chart
- update range handling to render the augmented series and expose the helper for tests
- extend security detail tests to cover the live price injection logic

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e4e26dc6688330869b48972185fb86