### PR TITLE
Fix ppreader panel re-registration race

### DIFF
--- a/tests/test_panel_registration.py
+++ b/tests/test_panel_registration.py
@@ -74,11 +74,11 @@ async def test_placeholder_panel_registered_during_setup(
 
     captured_configs: list[dict[str, Any]] = []
 
-    async def fake_register_panel(*args, **kwargs):  # noqa: ANN002, ANN003
+    def fake_register_panel(*args, **kwargs):  # noqa: ANN002, ANN003
         captured_configs.append(kwargs.get("config", {}))
 
     monkeypatch.setattr(
-        "custom_components.pp_reader.__init__.panel_custom_async_register_panel",
+        "custom_components.pp_reader.__init__.async_register_built_in_panel",
         fake_register_panel,
     )
 


### PR DESCRIPTION
## Summary
- update the panel registration logic to reuse the existing Home Assistant panel instead of removing it, eliminating transient 404s on /ppreader during startup
- adapt the placeholder panel unit test to patch the new registration helper

## Testing
- pytest tests/test_panel_registration.py


------
https://chatgpt.com/codex/tasks/task_e_68e5083f380c8330bb1c4142a79f9c8b