### PR TITLE
Fix baseline fallback for security detail chart

### DIFF
--- a/src/tabs/__tests__/security_detail.metrics.test.ts
+++ b/src/tabs/__tests__/security_detail.metrics.test.ts
@@ -15,7 +15,12 @@ const {
   getHistoryChartOptionsForTest,
   clearSnapshotMetricsRegistryForTest,
   mergeHistoryWithSnapshotPriceForTest,
+  resolveAveragePurchaseBaselineForTest,
 } = __TEST_ONLY__;
+
+type SecuritySnapshotMetricsLike = NonNullable<
+  ReturnType<typeof ensureSnapshotMetricsForTest>
+>;
 
 test('ensureSnapshotMetricsForTest returns provided native averages verbatim', () => {
   clearSnapshotMetricsRegistryForTest();
@@ -103,6 +108,30 @@ test('getHistoryChartOptionsForTest injects the native baseline into chart optio
   });
 
   assert.match(tooltipContent, /USD/);
+});
+
+test('resolveAveragePurchaseBaselineForTest falls back to snapshot values when metrics lack averages', () => {
+  const snapshot = {
+    average_purchase_price_native: '45.67',
+  } as const;
+
+  assert.strictEqual(
+    resolveAveragePurchaseBaselineForTest(null, snapshot),
+    45.67,
+  );
+
+  assert.strictEqual(
+    resolveAveragePurchaseBaselineForTest(
+      { averagePurchaseNative: 12.34 } as unknown as SecuritySnapshotMetricsLike,
+      snapshot,
+    ),
+    12.34,
+  );
+
+  assert.strictEqual(
+    resolveAveragePurchaseBaselineForTest(null, null),
+    null,
+  );
 });
 
 test('mergeHistoryWithSnapshotPriceForTest appends the latest snapshot price for new days', () => {


### PR DESCRIPTION
## Summary
- resolve the history chart baseline from snapshot metrics or the snapshot payload so the average purchase price line is always available
- expose the baseline resolver for tests and cover the fallback behaviour in the security detail metrics suite

## Testing
- npm run lint:ts *(fails: existing repository lint violations)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e55ba823e48330ad31166a9ed1a665