### PR TITLE
Extend purchase computation fields

### DIFF
--- a/.docs/TODO_fix_native_purchase.md
+++ b/.docs/TODO_fix_native_purchase.md
@@ -13,7 +13,7 @@
       - Ziel: Ergänzt Rückgabe des verwendeten FX-Kurses, damit `net_trade_account / fx_rate` als Ersatz für fehlende `fx_amount` genutzt werden kann.
 
 2. Backend: Sicherheitswährungs-Kaufsummen berechnen
-   a) [ ] Kaufmetriken um Sicherheitswährungsfelder erweitern
+   a) [x] Kaufmetriken um Sicherheitswährungsfelder erweitern
       - Datei: `custom_components/pp_reader/logic/securities.py`
       - Dataklasse: `PurchaseComputation`
       - Ziel: Zusätzliche Attribute `security_currency_total`, `account_currency_total`, `avg_price_security`, `avg_price_account` vorhalten.

--- a/custom_components/pp_reader/logic/securities.py
+++ b/custom_components/pp_reader/logic/securities.py
@@ -106,6 +106,10 @@ class PurchaseComputation:
 
     purchase_value: float
     avg_price_native: float | None
+    security_currency_total: float = 0.0
+    account_currency_total: float = 0.0
+    avg_price_security: float | None = None
+    avg_price_account: float | None = None
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- extend `PurchaseComputation` to track security and account currency totals
- add placeholders for averaged purchase prices in both currencies
- mark the corresponding TODO checklist item as complete

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e61b00d4248330a11bf3452d524d54