### PR TITLE
Extend portfolio security upsert with native totals

### DIFF
--- a/.docs/TODO_fix_native_purchase.md
+++ b/.docs/TODO_fix_native_purchase.md
@@ -27,7 +27,7 @@
       - Ziel: Loggt warnend, wenn weder `type = 0` noch ein FX-Kurs verfügbar ist, und markiert die Position für manuelle Prüfung.
 
 3. Backend: Persistierte Portfolio-Daten anreichern
-   a) [ ] `portfolio_securities`-Upsert erweitern
+   a) [x] `portfolio_securities`-Upsert erweitern
       - Datei: `custom_components/pp_reader/prices/price_service.py`
       - Funktion: `_refresh_portfolio_securities`
       - Ziel: Schreibt neue Werte (`security_currency_total`, `account_currency_total`, `avg_price_security`, `avg_price_account`) in zusätzliche Spalten des Upserts.


### PR DESCRIPTION
## Summary
- expand the portfolio security refresh to collect previously stored purchase metrics
- persist security and account currency totals plus average prices in the upsert
- mark the native purchase TODO item as complete

## Testing
- python -m compileall custom_components/pp_reader/prices/price_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e62e405c2083309f260d1f74c8f268