### PR TITLE
Align event push payload with purchase metrics

### DIFF
--- a/.docs/TODO_fix_native_purchase.md
+++ b/.docs/TODO_fix_native_purchase.md
@@ -39,7 +39,7 @@
       - Datei: `custom_components/pp_reader/data/websocket.py`
       - Funktionen: `_normalize_security_snapshot`, `_normalize_portfolio_positions`
       - Ziel: Serialisiert neue Felder (`purchase_total_security`, `purchase_total_account`, `avg_price_security`, `avg_price_account`).
-   d) [ ] Event-Push angleichen
+   d) [x] Event-Push angleichen
       - Datei: `custom_components/pp_reader/data/event_push.py`
       - Funktion: `_build_security_payload`
       - Ziel: Stellt sicher, dass Push-Events die erweiterten Kaufdaten enthalten.

--- a/custom_components/pp_reader/data/event_push.py
+++ b/custom_components/pp_reader/data/event_push.py
@@ -129,6 +129,15 @@ def _normalize_position_entry(item: Mapping[str, Any]) -> dict[str, Any] | None:
         except (TypeError, ValueError):
             avg_native = None
 
+    def _optional_price(value_key: str) -> float | None:
+        raw_value = item.get(value_key)
+        if raw_value is None:
+            return None
+        try:
+            return round(float(raw_value), 6)
+        except (TypeError, ValueError):
+            return None
+
     normalized: dict[str, Any] = {
         "security_uuid": security_uuid,
         "name": item.get("name"),
@@ -138,6 +147,10 @@ def _normalize_position_entry(item: Mapping[str, Any]) -> dict[str, Any] | None:
         "gain_abs": _float("gain_abs"),
         "gain_pct": _float("gain_pct"),
         "average_purchase_price_native": avg_native,
+        "purchase_total_security": _float("purchase_total_security"),
+        "purchase_total_account": _float("purchase_total_account"),
+        "avg_price_security": _optional_price("avg_price_security"),
+        "avg_price_account": _optional_price("avg_price_account"),
     }
 
     return normalized


### PR DESCRIPTION
## Summary
- extend the event push normalization to include purchase totals and average price fields added to other backends
- share rounding helpers that keep purchase totals at two decimals and price fields at six decimals
- mark the native purchase fix checklist entry for the event push payload as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63b17b6fc8330b1ce6156c09e6bb6