### PR TITLE
feat: extend frontend websocket types for purchase totals

### DIFF
--- a/.docs/TODO_fix_native_purchase.md
+++ b/.docs/TODO_fix_native_purchase.md
@@ -59,7 +59,7 @@
       - Ziel: Bestehende `portfolio_securities`-Einträge initial mit 0 bzw. `NULL` für die neuen Spalten befüllen.
 
 5. Frontend: API- und Typdefinitionen aktualisieren
-   a) [ ] Websocket-Response-Typen erweitern
+   a) [x] Websocket-Response-Typen erweitern
       - Datei: `src/data/api.ts`
       - Interface: `SecuritySnapshotResponse`, `PortfolioPosition`
       - Ziel: Neue Felder für Kaufwerte und Durchschnittspreise deklarieren.

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -49,6 +49,11 @@ export interface PortfolioPosition {
   current_value: number;
   gain_abs: number;
   gain_pct: number;
+  average_purchase_price_native?: number | null;
+  purchase_total_security: number;
+  purchase_total_account: number;
+  avg_price_security: number | null;
+  avg_price_account: number | null;
   [key: string]: unknown;
 }
 
@@ -71,6 +76,10 @@ export interface SecuritySnapshotResponse {
     last_price_eur?: number;
     market_value_eur?: number | null;
     average_purchase_price_native?: number | string | null;
+    purchase_total_security?: number;
+    purchase_total_account?: number;
+    avg_price_security?: number | null;
+    avg_price_account?: number | null;
     last_close_native?: number | null;
     last_close_eur?: number | null;
     [key: string]: unknown;


### PR DESCRIPTION
## Summary
- align the `SecuritySnapshotResponse` websocket payload type with purchase totals and averages
- extend the `PortfolioPosition` type to cover the new purchase metrics
- mark the native purchase TODO checklist entry as complete

## Testing
- not run (TypeScript type adjustments only)


------
https://chatgpt.com/codex/tasks/task_e_68e6569dd8848330b4cb48a9e48cfe60