### PR TITLE
Prioritize security currency purchase metrics in detail view

### DIFF
--- a/.docs/TODO_fix_native_purchase.md
+++ b/.docs/TODO_fix_native_purchase.md
@@ -69,7 +69,7 @@
       - Ziel: Stellt Frontend-Typen auf die erweiterten Backend-Felder ein.
 
 6. Frontend: Darstellung der Kaufpreise anpassen
-   a) [ ] Sicherheitsdetailansicht priorisiert Sicherheitswährung
+   a) [x] Sicherheitsdetailansicht priorisiert Sicherheitswährung
       - Datei: `src/tabs/security_detail.ts`
       - Bereiche: `ensureSnapshotMetrics`, `renderOverviewCard`
       - Ziel: Nutzt `avg_price_security` als Hauptwert, zeigt Kontowährungsreferenz sekundär an.


### PR DESCRIPTION
## Summary
- trust the backend-provided security currency purchase totals when caching snapshot metrics
- surface the account-currency reference as the secondary value in the security detail header
- update the native purchase checklist entry for the security detail view

## Testing
- npm run lint:ts *(fails: missing @eslint/js dependency in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e667266e3483309800fc3b644d1ffd